### PR TITLE
Use an extensible effects type.

### DIFF
--- a/src/Test/QuickCheck/Laws/Control/Alt.purs
+++ b/src/Test/QuickCheck/Laws/Control/Alt.purs
@@ -13,7 +13,7 @@ import Test.QuickCheck.Laws (A(), B())
 
 -- | - Associativity: `(x <|> y) <|> z == x <|> (y <|> z)`
 -- | - Distributivity: `f <$> (x <|> y) == (f <$> x) <|> (f <$> y)`
-checkAlt :: forall f. (Alt f, Arbitrary (f A), Eq (f A), Eq (f B)) => Proxy2 f -> QC () Unit
+checkAlt :: forall eff f. (Alt f, Arbitrary (f A), Eq (f A), Eq (f B)) => Proxy2 f -> QC eff Unit
 checkAlt _ = do
 
   log "Checking 'Associativity' law for Alt"

--- a/src/Test/QuickCheck/Laws/Control/Alternative.purs
+++ b/src/Test/QuickCheck/Laws/Control/Alternative.purs
@@ -15,7 +15,7 @@ import Test.QuickCheck.Laws (A(), B())
 
 -- | - Distributivity: `(f <|> g) <*> x == (f <*> x) <|> (g <*> x)`
 -- | - Annihilation: `empty <*> x = empty`
-checkAlternative :: forall f. (Alternative f, Arbitrary (f (A -> B)), Arbitrary (f A), Eq (f A), Eq (f B)) => Proxy2 f -> QC () Unit
+checkAlternative :: forall eff f. (Alternative f, Arbitrary (f (A -> B)), Arbitrary (f A), Eq (f A), Eq (f B)) => Proxy2 f -> QC eff Unit
 checkAlternative _ = do
 
   log "Checking 'Left identity' law for Alternative"

--- a/src/Test/QuickCheck/Laws/Control/Applicative.purs
+++ b/src/Test/QuickCheck/Laws/Control/Applicative.purs
@@ -14,7 +14,7 @@ import Test.QuickCheck.Laws (A(), B(), C())
 -- | - Composition: `(pure (<<<)) <*> f <*> g <*> h = f <*> (g <*> h)`
 -- | - Homomorphism: `(pure f) <*> (pure x) = pure (f x)`
 -- | - Interchange: `u <*> (pure y) = (pure ($ y)) <*> u`
-checkApplicative :: forall f. (Applicative f, Arbitrary (f A), Arbitrary (f (A -> B)), Arbitrary (f (B -> C)), Eq (f A), Eq (f B), Eq (f C)) => Proxy2 f -> QC () Unit
+checkApplicative :: forall eff f. (Applicative f, Arbitrary (f A), Arbitrary (f (A -> B)), Arbitrary (f (B -> C)), Eq (f A), Eq (f B), Eq (f C)) => Proxy2 f -> QC eff Unit
 checkApplicative _ = do
 
   log "Checking 'Identity' law for Applicative"

--- a/src/Test/QuickCheck/Laws/Control/Apply.purs
+++ b/src/Test/QuickCheck/Laws/Control/Apply.purs
@@ -11,7 +11,7 @@ import Test.QuickCheck.Arbitrary (Arbitrary)
 import Test.QuickCheck.Laws (A(), B(), C())
 
 -- | - Associative composition: `(<<<) <$> f <*> g <*> h = f <*> (g <*> h)`
-checkApply :: forall f. (Apply f, Arbitrary (f A), Arbitrary (f (A -> B)), Arbitrary (f (B -> C)), Eq (f C)) => Proxy2 f -> QC () Unit
+checkApply :: forall eff f. (Apply f, Arbitrary (f A), Arbitrary (f (A -> B)), Arbitrary (f (B -> C)), Eq (f C)) => Proxy2 f -> QC eff Unit
 checkApply _ = do
 
   log "Checking 'Associative composition' law for Apply"

--- a/src/Test/QuickCheck/Laws/Control/Bind.purs
+++ b/src/Test/QuickCheck/Laws/Control/Bind.purs
@@ -11,7 +11,7 @@ import Test.QuickCheck.Arbitrary (Arbitrary)
 import Test.QuickCheck.Laws (A())
 
 -- | - Associativity: `(x >>= f) >>= g = x >>= (\k => f k >>= g)`
-checkBind :: forall m. (Bind m, Arbitrary (m A), Eq (m A)) => Proxy2 m -> QC () Unit
+checkBind :: forall eff m. (Bind m, Arbitrary (m A), Eq (m A)) => Proxy2 m -> QC eff Unit
 checkBind _ = do
 
   log "Checking 'Associativity' law for Bind"

--- a/src/Test/QuickCheck/Laws/Control/Category.purs
+++ b/src/Test/QuickCheck/Laws/Control/Category.purs
@@ -11,7 +11,7 @@ import Test.QuickCheck.Arbitrary (Arbitrary)
 import Test.QuickCheck.Laws (B(), C())
 
 -- | - Identity: `id <<< p = p <<< id = p`
-checkCategory :: forall a. (Category a, Arbitrary (a B C), Eq (a B C)) => Proxy3 a -> QC () Unit
+checkCategory :: forall eff a. (Category a, Arbitrary (a B C), Eq (a B C)) => Proxy3 a -> QC eff Unit
 checkCategory _ = do
 
   log "Checking 'Identity' law for Category"

--- a/src/Test/QuickCheck/Laws/Control/Comonad.purs
+++ b/src/Test/QuickCheck/Laws/Control/Comonad.purs
@@ -14,7 +14,7 @@ import Test.QuickCheck.Laws (A(), B())
 
 -- | - Left Identity: `extract <<= x = x`
 -- | - Right Identity: `extract (f <<= x) = f x`
-checkComonad :: forall w. (Comonad w, Arbitrary (w A), Coarbitrary (w A), Eq (w A)) => Proxy2 w -> QC () Unit
+checkComonad :: forall eff w. (Comonad w, Arbitrary (w A), Coarbitrary (w A), Eq (w A)) => Proxy2 w -> QC eff Unit
 checkComonad _ = do
 
   log "Checking 'Left identity' law for Comonad"

--- a/src/Test/QuickCheck/Laws/Control/Extend.purs
+++ b/src/Test/QuickCheck/Laws/Control/Extend.purs
@@ -12,7 +12,7 @@ import Test.QuickCheck.Arbitrary (Arbitrary, Coarbitrary)
 import Test.QuickCheck.Laws (A(), B(), C())
 
 -- | - Associativity: `extend f <<< extend g = extend (f <<< extend g)`
-checkExtend :: forall w. (Extend w, Arbitrary (w A), Coarbitrary (w A), Coarbitrary (w B), Eq (w C)) => Proxy2 w -> QC () Unit
+checkExtend :: forall eff w. (Extend w, Arbitrary (w A), Coarbitrary (w A), Coarbitrary (w B), Eq (w C)) => Proxy2 w -> QC eff Unit
 checkExtend _ = do
 
   log "Checking 'Associativity' law for Extend"

--- a/src/Test/QuickCheck/Laws/Control/Monad.purs
+++ b/src/Test/QuickCheck/Laws/Control/Monad.purs
@@ -12,7 +12,7 @@ import Test.QuickCheck.Laws (A())
 
 -- | - Left Identity: `pure x >>= f = f x`
 -- | - Right Identity: `x >>= pure = x`
-checkMonad :: forall m. (Monad m, Arbitrary (m A), Eq (m A)) => Proxy2 m -> QC () Unit
+checkMonad :: forall eff m. (Monad m, Arbitrary (m A), Eq (m A)) => Proxy2 m -> QC eff Unit
 checkMonad _ = do
 
   log "Checking 'Left identity' law for Monad"

--- a/src/Test/QuickCheck/Laws/Control/MonadPlus.purs
+++ b/src/Test/QuickCheck/Laws/Control/MonadPlus.purs
@@ -15,7 +15,7 @@ import Test.QuickCheck.Laws (A(), B())
 
 -- | - Distributivity: `(x <|> y) >>= f == (x >>= f) <|> (y >>= f)`
 -- | - Annihilation: `empty >>= f = empty`
-checkMonadPlus :: forall m. (MonadPlus m, Arbitrary (m A), Arbitrary (m B), Eq (m B)) => Proxy2 m -> QC () Unit
+checkMonadPlus :: forall eff m. (MonadPlus m, Arbitrary (m A), Arbitrary (m B), Eq (m B)) => Proxy2 m -> QC eff Unit
 checkMonadPlus _ = do
 
   log "Checking 'Distributivity' law for MonadPlus"

--- a/src/Test/QuickCheck/Laws/Control/Plus.purs
+++ b/src/Test/QuickCheck/Laws/Control/Plus.purs
@@ -15,7 +15,7 @@ import Test.QuickCheck.Laws (A(), B())
 -- | - Left identity: `empty <|> x == x`
 -- | - Right identity: `x <|> empty == x`
 -- | - Annihilation: `f <$> empty == empty`
-checkPlus :: forall f. (Plus f, Arbitrary (f A), Eq (f A), Eq (f B)) => Proxy2 f -> QC () Unit
+checkPlus :: forall eff f. (Plus f, Arbitrary (f A), Eq (f A), Eq (f B)) => Proxy2 f -> QC eff Unit
 checkPlus _ = do
 
   log "Checking 'Left identity' law for Plus"

--- a/src/Test/QuickCheck/Laws/Control/Semigroupoid.purs
+++ b/src/Test/QuickCheck/Laws/Control/Semigroupoid.purs
@@ -11,7 +11,7 @@ import Test.QuickCheck.Arbitrary (Arbitrary)
 import Test.QuickCheck.Laws (B(), C(), D(), E())
 
 -- | - Associativity: `p <<< (q <<< r) = (p <<< q) <<< r`
-checkSemigroupoid :: forall a. (Semigroupoid a, Arbitrary (a B C), Arbitrary (a C D), Arbitrary (a D E), Eq (a B E)) => Proxy3 a -> QC () Unit
+checkSemigroupoid :: forall eff a. (Semigroupoid a, Arbitrary (a B C), Arbitrary (a C D), Arbitrary (a D E), Eq (a B E)) => Proxy3 a -> QC eff Unit
 checkSemigroupoid _ = do
 
   log "Checking 'Associativity' law for Semigroupoid"

--- a/src/Test/QuickCheck/Laws/Data/Bounded.purs
+++ b/src/Test/QuickCheck/Laws/Data/Bounded.purs
@@ -10,7 +10,7 @@ import Test.QuickCheck (QC(), quickCheck')
 import Test.QuickCheck.Arbitrary (Arbitrary)
 
 -- | - Ordering: `bottom <= a <= top`
-checkBounded :: forall a. (Arbitrary a, Bounded a, Ord a) => Proxy a -> QC () Unit
+checkBounded :: forall eff a. (Arbitrary a, Bounded a, Ord a) => Proxy a -> QC eff Unit
 checkBounded _ = do
 
   log "Checking 'Ordering' law for Bounded"

--- a/src/Test/QuickCheck/Laws/Data/DivisionRing.purs
+++ b/src/Test/QuickCheck/Laws/Data/DivisionRing.purs
@@ -10,7 +10,7 @@ import Test.QuickCheck (QC(), quickCheck')
 import Test.QuickCheck.Arbitrary (Arbitrary)
 
 -- | - Multiplicative inverse: `(one / x) * x = one`
-checkDivisionRing :: forall a. (DivisionRing a, Arbitrary a, Eq a) => Proxy a -> QC () Unit
+checkDivisionRing :: forall eff a. (DivisionRing a, Arbitrary a, Eq a) => Proxy a -> QC eff Unit
 checkDivisionRing _ = do
 
   log "Checking 'Multiplicative inverse' law for DivisionRing"

--- a/src/Test/QuickCheck/Laws/Data/Eq.purs
+++ b/src/Test/QuickCheck/Laws/Data/Eq.purs
@@ -13,7 +13,7 @@ import Test.QuickCheck.Arbitrary (Arbitrary)
 -- | - Symmetry: `x == y = y == x`
 -- | - Transitivity: if `x == y` and `y == z` then `x == z`
 -- | - Negation: `x /= y = not (x == y)`
-checkEq :: forall a. (Arbitrary a, Eq a) => Proxy a -> QC () Unit
+checkEq :: forall eff a. (Arbitrary a, Eq a) => Proxy a -> QC eff Unit
 checkEq _ = do
 
   log "Checking 'Reflexivity' law for Eq"

--- a/src/Test/QuickCheck/Laws/Data/Functor.purs
+++ b/src/Test/QuickCheck/Laws/Data/Functor.purs
@@ -12,7 +12,7 @@ import Test.QuickCheck.Laws (A(), B())
 
 -- | - Identity: `(<$>) id = id`
 -- | - Composition: `(<$>) (f <<< g) = (f <$>) <<< (g <$>)`
-checkFunctor :: forall f. (Functor f, Arbitrary (f A), Eq (f A)) => Proxy2 f -> QC () Unit
+checkFunctor :: forall eff f. (Functor f, Arbitrary (f A), Eq (f A)) => Proxy2 f -> QC eff Unit
 checkFunctor _ = do
 
   log "Checking 'Identity' law for Functor"

--- a/src/Test/QuickCheck/Laws/Data/ModuloSemiring.purs
+++ b/src/Test/QuickCheck/Laws/Data/ModuloSemiring.purs
@@ -10,7 +10,7 @@ import Test.QuickCheck (QC(), quickCheck')
 import Test.QuickCheck.Arbitrary (Arbitrary)
 
 -- | - Remainder: ```a / b * b + (a `mod` b) = a```
-checkModuloSemiring :: forall a. (ModuloSemiring a, Arbitrary a, Eq a) => Proxy a -> QC () Unit
+checkModuloSemiring :: forall eff a. (ModuloSemiring a, Arbitrary a, Eq a) => Proxy a -> QC eff Unit
 checkModuloSemiring _ = do
 
   log "Checking 'Remainder' law for ModuloSemiring"

--- a/src/Test/QuickCheck/Laws/Data/Monoid.purs
+++ b/src/Test/QuickCheck/Laws/Data/Monoid.purs
@@ -13,7 +13,7 @@ import Test.QuickCheck.Arbitrary (Arbitrary)
 
 -- | - Left identity: `mempty <> x = x`
 -- | - Right identity: `x <> mempty = x`
-checkMonoid :: forall m. (Monoid m, Arbitrary m, Eq m) => Proxy m -> QC () Unit
+checkMonoid :: forall eff m. (Monoid m, Arbitrary m, Eq m) => Proxy m -> QC eff Unit
 checkMonoid _ = do
 
   log "Checking 'Left identity' law for Monoid"

--- a/src/Test/QuickCheck/Laws/Data/Num.purs
+++ b/src/Test/QuickCheck/Laws/Data/Num.purs
@@ -10,7 +10,7 @@ import Test.QuickCheck (QC(), quickCheck')
 import Test.QuickCheck.Arbitrary (Arbitrary)
 
 -- | - Commutative multiplication: `a * b = b * a`
-checkNum :: forall a. (Num a, Arbitrary a, Eq a) => Proxy a -> QC () Unit
+checkNum :: forall eff a. (Num a, Arbitrary a, Eq a) => Proxy a -> QC eff Unit
 checkNum _ = do
 
   log "Checking 'Commutative multiplication' law for Num"

--- a/src/Test/QuickCheck/Laws/Data/Ord.purs
+++ b/src/Test/QuickCheck/Laws/Data/Ord.purs
@@ -12,7 +12,7 @@ import Test.QuickCheck.Arbitrary (Arbitrary)
 -- | - Reflexivity: `a <= a`
 -- | - Antisymmetry: if `a <= b` and `b <= a` then `a = b`
 -- | - Transitivity: if `a <= b` and `b <= c` then `a <= c`
-checkOrd :: forall a. (Arbitrary a, Ord a) => Proxy a -> QC () Unit
+checkOrd :: forall eff a. (Arbitrary a, Ord a) => Proxy a -> QC eff Unit
 checkOrd _ = do
 
   log "Checking 'Reflexivity' law for Ord"

--- a/src/Test/QuickCheck/Laws/Data/Ring.purs
+++ b/src/Test/QuickCheck/Laws/Data/Ring.purs
@@ -10,7 +10,7 @@ import Test.QuickCheck (QC(), quickCheck')
 import Test.QuickCheck.Arbitrary (Arbitrary)
 
 -- | - Additive inverse: `a + (-a) = (-a) + a = zero`
-checkRing :: forall a. (Ring a, Arbitrary a, Eq a) => Proxy a -> QC () Unit
+checkRing :: forall eff a. (Ring a, Arbitrary a, Eq a) => Proxy a -> QC eff Unit
 checkRing _ = do
 
   log "Checking 'Additive inverse' law for Ring"

--- a/src/Test/QuickCheck/Laws/Data/Semigroup.purs
+++ b/src/Test/QuickCheck/Laws/Data/Semigroup.purs
@@ -10,7 +10,7 @@ import Test.QuickCheck (QC(), quickCheck')
 import Test.QuickCheck.Arbitrary (Arbitrary)
 
 -- | - Associativity: `(x <> y) <> z = x <> (y <> z)`
-checkSemigroup :: forall s. (Semigroup s, Arbitrary s, Eq s) => Proxy s -> QC () Unit
+checkSemigroup :: forall eff s. (Semigroup s, Arbitrary s, Eq s) => Proxy s -> QC eff Unit
 checkSemigroup _ = do
 
   log "Checking 'Associativity' law for Semigroup"

--- a/src/Test/QuickCheck/Laws/Data/Semiring.purs
+++ b/src/Test/QuickCheck/Laws/Data/Semiring.purs
@@ -20,7 +20,7 @@ import Test.QuickCheck.Arbitrary (Arbitrary)
 -- |   - Left distributivity: `a * (b + c) = (a * b) + (a * c)`
 -- |   - Right distributivity: `(a + b) * c = (a * c) + (b * c)`
 -- | - Annihiliation: `zero * a = a * zero = zero`
-checkSemiring :: forall a. (Semiring a, Arbitrary a, Eq a) => Proxy a -> QC () Unit
+checkSemiring :: forall eff a. (Semiring a, Arbitrary a, Eq a) => Proxy a -> QC eff Unit
 checkSemiring _ = do
 
   log "Checking 'Associativity' law for Semiring addition"


### PR DESCRIPTION
I thought it would be nice to re-use your module to help test my own code.

However, I had some difficulty integrating your code with other test code, because of the closed row of effects. So, I've modified each check... function to use an extensible row of effects.

For an example of how I'm using this, see:

https://github.com/rgrempel/purescript-elm/blob/master/test/Elm/Int53Test.purs#L72-L78

Of course, if there's a better way to re-use this code, that would be fine with me too!
