### PR TITLE
Bump versions and update for 0.12

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,8 +20,8 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-proxy": "^2.0.0",
-    "purescript-enums": "^3.0.0", 
-    "purescript-quickcheck": "^4.0.0"
+    "purescript-proxy": "^3.0.0",
+    "purescript-enums": "^4.0.0",
+    "purescript-quickcheck": "^5.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
     "test": "pulp test"
   },
   "devDependencies": {
-    "pulp": "^11.0.0",
-    "purescript-psa": "^0.5.0",
-    "purescript": "^0.11.1",
-    "rimraf": "^2.6.1"
+    "pulp": "^12.3.0",
+    "purescript-psa": "^0.6.0",
+    "purescript": "^0.12.0",
+    "rimraf": "^2.6.2"
   }
 }

--- a/src/Test/QuickCheck/Laws.purs
+++ b/src/Test/QuickCheck/Laws.purs
@@ -1,16 +1,14 @@
 module Test.QuickCheck.Laws
   ( module Test.QuickCheck.Laws
-  , module Test.QuickCheck
   ) where
 
 import Prelude
-import Control.Monad.Eff.Console (log)
+import Effect (Effect)
+import Effect.Console (log)
 import Data.Enum (class Enum, class BoundedEnum)
-import Data.Monoid (class Monoid)
-import Test.QuickCheck (QC)
 import Test.QuickCheck.Arbitrary (class Arbitrary, class Coarbitrary)
 
-checkLaws ∷ ∀ eff. String → QC eff Unit → QC eff Unit
+checkLaws ∷ String → Effect Unit → Effect Unit
 checkLaws typeName laws = do
   log $ "\n\nChecking laws of " <> typeName <> " instances...\n"
   laws

--- a/src/Test/QuickCheck/Laws/Control/Alt.purs
+++ b/src/Test/QuickCheck/Laws/Control/Alt.purs
@@ -3,24 +3,25 @@ module Test.QuickCheck.Laws.Control.Alt where
 import Prelude
 
 import Control.Alt (class Alt, (<|>))
-import Control.Monad.Eff.Console (log)
+import Effect (Effect)
+import Effect.Console (log)
 
 import Type.Proxy (Proxy2)
 
-import Test.QuickCheck (QC, quickCheck')
+import Test.QuickCheck (quickCheck')
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 import Test.QuickCheck.Laws (A, B)
 
 -- | - Associativity: `(x <|> y) <|> z == x <|> (y <|> z)`
 -- | - Distributivity: `f <$> (x <|> y) == (f <$> x) <|> (f <$> y)`
 checkAlt
-  ∷ ∀ eff f
+  ∷ ∀ f
   . Alt f
   ⇒ Arbitrary (f A)
   ⇒ Eq (f A)
   ⇒ Eq (f B)
   ⇒ Proxy2 f
-  → QC eff Unit
+  → Effect Unit
 checkAlt _ = do
 
   log "Checking 'Associativity' law for Alt"

--- a/src/Test/QuickCheck/Laws/Control/Alternative.purs
+++ b/src/Test/QuickCheck/Laws/Control/Alternative.purs
@@ -4,26 +4,27 @@ import Prelude
 
 import Control.Alt ((<|>))
 import Control.Alternative (class Alternative)
-import Control.Monad.Eff.Console (log)
+import Effect (Effect)
+import Effect.Console (log)
 import Control.Plus (empty)
 
 import Type.Proxy (Proxy2)
 
-import Test.QuickCheck (QC, quickCheck')
+import Test.QuickCheck (quickCheck')
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 import Test.QuickCheck.Laws (A, B)
 
 -- | - Distributivity: `(f <|> g) <*> x == (f <*> x) <|> (g <*> x)`
 -- | - Annihilation: `empty <*> x = empty`
 checkAlternative
-  ∷ ∀ eff f
+  ∷ ∀ f
   . Alternative f
   ⇒ Arbitrary (f (A → B))
   ⇒ Arbitrary (f A)
   ⇒ Eq (f A)
   ⇒ Eq (f B)
   ⇒ Proxy2 f
-  → QC eff Unit
+  → Effect Unit
 checkAlternative _ = do
 
   log "Checking 'Left identity' law for Alternative"
@@ -38,4 +39,4 @@ checkAlternative _ = do
   distributivity f g x = ((f <|> g) <*> x) == ((f <*> x) <|> (g <*> x))
 
   annihilation ∷ f A → Boolean
-  annihilation x = empty <*> x == empty ∷ f A
+  annihilation x = (empty <*> x) == empty ∷ f A

--- a/src/Test/QuickCheck/Laws/Control/Applicative.purs
+++ b/src/Test/QuickCheck/Laws/Control/Applicative.purs
@@ -2,20 +2,21 @@ module Test.QuickCheck.Laws.Control.Applicative where
 
 import Prelude
 
-import Control.Monad.Eff.Console (log)
+import Effect (Effect)
+import Effect.Console (log)
 
 import Type.Proxy (Proxy2)
 
-import Test.QuickCheck (QC, quickCheck')
+import Test.QuickCheck (quickCheck')
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 import Test.QuickCheck.Laws (A, B, C)
 
--- | - Identity: `(pure id) <*> v = v`
+-- | - Identity: `(pure identity) <*> v = v`
 -- | - Composition: `(pure (<<<)) <*> f <*> g <*> h = f <*> (g <*> h)`
 -- | - Homomorphism: `(pure f) <*> (pure x) = pure (f x)`
 -- | - Interchange: `u <*> (pure y) = (pure ($ y)) <*> u`
 checkApplicative
-  ∷ ∀ eff f
+  ∷ ∀ f
   . Applicative f
   ⇒ Arbitrary (f A)
   ⇒ Arbitrary (f (A → B))
@@ -24,11 +25,11 @@ checkApplicative
   ⇒ Eq (f B)
   ⇒ Eq (f C)
   ⇒ Proxy2 f
-  → QC eff Unit
+  → Effect Unit
 checkApplicative _ = do
 
   log "Checking 'Identity' law for Applicative"
-  quickCheck' 1000 identity
+  quickCheck' 1000 identity'
 
   log "Checking 'Composition' law for Applicative"
   quickCheck' 1000 composition
@@ -41,8 +42,8 @@ checkApplicative _ = do
 
   where
 
-  identity ∷ f A → Boolean
-  identity v = (pure id <*> v) == v
+  identity' ∷ f A → Boolean
+  identity' v = (pure identity <*> v) == v
 
   composition ∷ f (B → C) → f (A → B) → f A → Boolean
   composition f g x = (pure (<<<) <*> f <*> g <*> x) == (f <*> (g <*> x))

--- a/src/Test/QuickCheck/Laws/Control/Apply.purs
+++ b/src/Test/QuickCheck/Laws/Control/Apply.purs
@@ -2,24 +2,25 @@ module Test.QuickCheck.Laws.Control.Apply where
 
 import Prelude
 
-import Control.Monad.Eff.Console (log)
+import Effect (Effect)
+import Effect.Console (log)
 
 import Type.Proxy (Proxy2)
 
-import Test.QuickCheck (QC, quickCheck')
+import Test.QuickCheck (quickCheck')
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 import Test.QuickCheck.Laws (A, B, C)
 
 -- | - Associative composition: `(<<<) <$> f <*> g <*> h = f <*> (g <*> h)`
 checkApply
-  ∷ ∀ eff f
+  ∷ ∀ f
   . Apply f
   ⇒ Arbitrary (f A)
   ⇒ Arbitrary (f (A → B))
   ⇒ Arbitrary (f (B → C))
   ⇒ Eq (f C)
   ⇒ Proxy2 f
-  → QC eff Unit
+  → Effect Unit
 checkApply _ = do
 
   log "Checking 'Associative composition' law for Apply"

--- a/src/Test/QuickCheck/Laws/Control/Bind.purs
+++ b/src/Test/QuickCheck/Laws/Control/Bind.purs
@@ -2,22 +2,23 @@ module Test.QuickCheck.Laws.Control.Bind where
 
 import Prelude
 
-import Control.Monad.Eff.Console (log)
+import Effect (Effect)
+import Effect.Console (log)
 
 import Type.Proxy (Proxy2)
 
-import Test.QuickCheck (QC, quickCheck')
+import Test.QuickCheck (quickCheck')
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 import Test.QuickCheck.Laws (A)
 
 -- | - Associativity: `(x >>= f) >>= g = x >>= (\k → f k >>= g)`
 checkBind
-  ∷ ∀ eff m
+  ∷ ∀ m
   . Bind m
   ⇒ Arbitrary (m A)
   ⇒ Eq (m A)
   ⇒ Proxy2 m
-  → QC eff Unit
+  → Effect Unit
 checkBind _ = do
 
   log "Checking 'Associativity' law for Bind"

--- a/src/Test/QuickCheck/Laws/Control/Category.purs
+++ b/src/Test/QuickCheck/Laws/Control/Category.purs
@@ -2,29 +2,30 @@ module Test.QuickCheck.Laws.Control.Category where
 
 import Prelude
 
-import Control.Monad.Eff.Console (log)
+import Effect (Effect)
+import Effect.Console (log)
 
 import Type.Proxy (Proxy3)
 
-import Test.QuickCheck (QC, quickCheck')
+import Test.QuickCheck (quickCheck')
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 import Test.QuickCheck.Laws (B, C)
 
 -- | - Identity: `id <<< p = p <<< id = p`
 checkCategory
-  ∷ ∀ eff a
+  ∷ ∀ a
   . Category a
   ⇒ Arbitrary (a B C)
   ⇒ Eq (a B C)
   ⇒ Proxy3 a
-  → QC eff Unit
+  → Effect Unit
 checkCategory _ = do
 
   log "Checking 'Identity' law for Category"
-  quickCheck' 1000 identity
+  quickCheck' 1000 identity'
 
   where
 
-  identity ∷ a B C → Boolean
-  identity p = (id <<< p) == p
-            && (p <<< id) == p
+  identity' ∷ a B C → Boolean
+  identity' p = (identity <<< p) == p
+            && (p <<< identity) == p

--- a/src/Test/QuickCheck/Laws/Control/Comonad.purs
+++ b/src/Test/QuickCheck/Laws/Control/Comonad.purs
@@ -2,26 +2,27 @@ module Test.QuickCheck.Laws.Control.Comonad where
 
 import Prelude
 
-import Control.Monad.Eff.Console (log)
+import Effect (Effect)
+import Effect.Console (log)
 import Control.Comonad (class Comonad, extract)
 import Control.Extend ((<<=))
 
 import Type.Proxy (Proxy2)
 
-import Test.QuickCheck (QC, quickCheck')
+import Test.QuickCheck (quickCheck')
 import Test.QuickCheck.Arbitrary (class Arbitrary, class Coarbitrary)
 import Test.QuickCheck.Laws (A, B)
 
 -- | - Left Identity: `extract <<= x = x`
 -- | - Right Identity: `extract (f <<= x) = f x`
 checkComonad
-  ∷ ∀ eff w
+  ∷ ∀ w
   . Comonad w
   ⇒ Arbitrary (w A)
   ⇒ Coarbitrary (w A)
   ⇒ Eq (w A)
   ⇒ Proxy2 w
-  → QC eff Unit
+  → Effect Unit
 checkComonad _ = do
 
   log "Checking 'Left identity' law for Comonad"

--- a/src/Test/QuickCheck/Laws/Control/Extend.purs
+++ b/src/Test/QuickCheck/Laws/Control/Extend.purs
@@ -3,24 +3,25 @@ module Test.QuickCheck.Laws.Control.Extend where
 import Prelude
 
 import Control.Extend (class Extend, (<<=))
-import Control.Monad.Eff.Console (log)
+import Effect (Effect)
+import Effect.Console (log)
 
 import Type.Proxy (Proxy2)
 
-import Test.QuickCheck (QC, quickCheck')
+import Test.QuickCheck (quickCheck')
 import Test.QuickCheck.Arbitrary (class Arbitrary, class Coarbitrary)
 import Test.QuickCheck.Laws (A, B, C)
 
 -- | - Associativity: `extend f <<< extend g = extend (f <<< extend g)`
 checkExtend
-  ∷ ∀ eff w
+  ∷ ∀ w
   . Extend w
   ⇒ Arbitrary (w A)
   ⇒ Coarbitrary (w A)
   ⇒ Coarbitrary (w B)
   ⇒ Eq (w C)
   ⇒ Proxy2 w
-  → QC eff Unit
+  → Effect Unit
 checkExtend _ = do
 
   log "Checking 'Associativity' law for Extend"

--- a/src/Test/QuickCheck/Laws/Control/Monad.purs
+++ b/src/Test/QuickCheck/Laws/Control/Monad.purs
@@ -2,23 +2,24 @@ module Test.QuickCheck.Laws.Control.Monad where
 
 import Prelude
 
-import Control.Monad.Eff.Console (log)
+import Effect (Effect)
+import Effect.Console (log)
 
 import Type.Proxy (Proxy2)
 
-import Test.QuickCheck (QC, quickCheck')
+import Test.QuickCheck (quickCheck')
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 import Test.QuickCheck.Laws (A)
 
 -- | - Left Identity: `pure x >>= f = f x`
 -- | - Right Identity: `x >>= pure = x`
 checkMonad
-  ∷ ∀ eff m
+  ∷ ∀ m
   . Monad m
   ⇒ Arbitrary (m A)
   ⇒ Eq (m A)
   ⇒ Proxy2 m
-  → QC eff Unit
+  → Effect Unit
 checkMonad _ = do
 
   log "Checking 'Left identity' law for Monad"

--- a/src/Test/QuickCheck/Laws/Control/MonadPlus.purs
+++ b/src/Test/QuickCheck/Laws/Control/MonadPlus.purs
@@ -3,24 +3,25 @@ module Test.QuickCheck.Laws.Control.MonadPlus where
 import Prelude
 
 import Control.Alt ((<|>))
-import Control.Monad.Eff.Console (log)
+import Effect (Effect)
+import Effect.Console (log)
 import Control.MonadPlus (class MonadPlus)
 
 import Type.Proxy (Proxy2)
 
-import Test.QuickCheck (QC, quickCheck')
+import Test.QuickCheck (quickCheck')
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 import Test.QuickCheck.Laws (A, B)
 
 -- | - Distributivity: `(x <|> y) >>= f == (x >>= f) <|> (y >>= f)`
 checkMonadPlus
-  ∷ ∀ eff m
+  ∷ ∀ m
   . MonadPlus m
   ⇒ Arbitrary (m A)
   ⇒ Arbitrary (m B)
   ⇒ Eq (m B)
   ⇒ Proxy2 m
-  → QC eff Unit
+  → Effect Unit
 checkMonadPlus _ = do
 
   log "Checking 'Distributivity' law for MonadPlus"

--- a/src/Test/QuickCheck/Laws/Control/MonadZero.purs
+++ b/src/Test/QuickCheck/Laws/Control/MonadZero.purs
@@ -2,25 +2,26 @@ module Test.QuickCheck.Laws.Control.MonadZero where
 
 import Prelude
 
-import Control.Monad.Eff.Console (log)
+import Effect (Effect)
+import Effect.Console (log)
 import Control.MonadZero (class MonadZero)
 import Control.Plus (empty)
 
 import Type.Proxy (Proxy2)
 
-import Test.QuickCheck (QC, quickCheck')
+import Test.QuickCheck (quickCheck')
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 import Test.QuickCheck.Laws (A, B)
 
 -- | - Annihilation: `empty >>= f = empty`
 checkMonadZero
-  ∷ ∀ eff m
+  ∷ ∀ m
   . MonadZero m
   ⇒ Arbitrary (m A)
   ⇒ Arbitrary (m B)
   ⇒ Eq (m B)
   ⇒ Proxy2 m
-  → QC eff Unit
+  → Effect Unit
 checkMonadZero _ = do
 
   log "Checking 'Annihilation' law for MonadZero"

--- a/src/Test/QuickCheck/Laws/Control/Plus.purs
+++ b/src/Test/QuickCheck/Laws/Control/Plus.purs
@@ -2,13 +2,14 @@ module Test.QuickCheck.Laws.Control.Plus where
 
 import Prelude
 
-import Control.Monad.Eff.Console (log)
+import Effect (Effect)
+import Effect.Console (log)
 import Control.Alt ((<|>))
 import Control.Plus (class Plus, empty)
 
 import Type.Proxy (Proxy2)
 
-import Test.QuickCheck (QC, quickCheck')
+import Test.QuickCheck (quickCheck')
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 import Test.QuickCheck.Laws (A, B)
 
@@ -16,13 +17,13 @@ import Test.QuickCheck.Laws (A, B)
 -- | - Right identity: `x <|> empty == x`
 -- | - Annihilation: `f <$> empty == empty`
 checkPlus
-  ∷ ∀ eff f
+  ∷ ∀ f
   . Plus f
   ⇒ Arbitrary (f A)
   ⇒ Eq (f A)
   ⇒ Eq (f B)
   ⇒ Proxy2 f
-  → QC eff Unit
+  → Effect Unit
 checkPlus _ = do
 
   log "Checking 'Left identity' law for Plus"
@@ -43,4 +44,4 @@ checkPlus _ = do
   rightIdentity x = (x <|> empty) == x
 
   annihilation ∷ (A → B) → Boolean
-  annihilation f = f <$> empty == empty ∷ f B
+  annihilation f = (f <$> empty) == empty ∷ f B

--- a/src/Test/QuickCheck/Laws/Control/Semigroupoid.purs
+++ b/src/Test/QuickCheck/Laws/Control/Semigroupoid.purs
@@ -2,24 +2,25 @@ module Test.QuickCheck.Laws.Control.Semigroupoid where
 
 import Prelude
 
-import Control.Monad.Eff.Console (log)
+import Effect (Effect)
+import Effect.Console (log)
 
 import Type.Proxy (Proxy3)
 
-import Test.QuickCheck (QC, quickCheck')
+import Test.QuickCheck (quickCheck')
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 import Test.QuickCheck.Laws (B, C, D, E)
 
 -- | - Associativity: `p <<< (q <<< r) = (p <<< q) <<< r`
 checkSemigroupoid
-  ∷ ∀ eff a
+  ∷ ∀ a
   . Semigroupoid a
   ⇒ Arbitrary (a B C)
   ⇒ Arbitrary (a C D)
   ⇒ Arbitrary (a D E)
   ⇒ Eq (a B E)
   ⇒ Proxy3 a
-  → QC eff Unit
+  → Effect Unit
 checkSemigroupoid _ = do
 
   log "Checking 'Associativity' law for Semigroupoid"

--- a/src/Test/QuickCheck/Laws/Data/BooleanAlgebra.purs
+++ b/src/Test/QuickCheck/Laws/Data/BooleanAlgebra.purs
@@ -2,23 +2,24 @@ module Test.QuickCheck.Laws.Data.BooleanAlgebra where
 
 import Prelude
 
-import Control.Monad.Eff.Console (log)
+import Effect (Effect)
+import Effect.Console (log)
 
 import Data.BooleanAlgebra (tt)
 
 import Type.Proxy (Proxy)
 
-import Test.QuickCheck (QC, quickCheck')
+import Test.QuickCheck (quickCheck')
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 
 -- | - Excluded middle: `a || not a = tt`
 checkBooleanAlgebra
-  ∷ ∀ eff a
+  ∷ ∀ a
   . Arbitrary a
   ⇒ BooleanAlgebra a
   ⇒ Eq a
   ⇒ Proxy a
-  → QC eff Unit
+  → Effect Unit
 checkBooleanAlgebra _ = do
 
   log "Checking 'Excluded middle' law for BooleanAlgebra"

--- a/src/Test/QuickCheck/Laws/Data/Bounded.purs
+++ b/src/Test/QuickCheck/Laws/Data/Bounded.purs
@@ -2,21 +2,22 @@ module Test.QuickCheck.Laws.Data.Bounded where
 
 import Prelude
 
-import Control.Monad.Eff.Console (log)
+import Effect (Effect)
+import Effect.Console (log)
 
 import Type.Proxy (Proxy)
 
-import Test.QuickCheck (QC, quickCheck')
+import Test.QuickCheck (quickCheck')
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 
 -- | - Ordering: `bottom <= a <= top`
 checkBounded
-  ∷ ∀ eff a
+  ∷ ∀ a
   . Arbitrary a
   ⇒ Bounded a
   ⇒ Ord a
   ⇒ Proxy a
-  → QC eff Unit
+  → Effect Unit
 checkBounded _ = do
 
   log "Checking 'Ordering' law for Bounded"

--- a/src/Test/QuickCheck/Laws/Data/BoundedEnum.purs
+++ b/src/Test/QuickCheck/Laws/Data/BoundedEnum.purs
@@ -2,12 +2,13 @@
 module Test.QuickCheck.Laws.Data.BoundedEnum where
 
 import Prelude
-import Control.Monad.Eff.Console (log)
+import Effect (Effect)
+import Effect.Console (log)
 import Data.Array (replicate, foldl)
 import Data.Enum (toEnum, Cardinality, cardinality, fromEnum, class BoundedEnum, pred, succ)
 import Data.Maybe (Maybe(Just))
 import Data.Newtype (unwrap)
-import Test.QuickCheck (QC, quickCheck')
+import Test.QuickCheck (quickCheck')
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 import Type.Proxy (Proxy)
 
@@ -22,12 +23,12 @@ import Type.Proxy (Proxy)
 -- | - tofromenum: toEnum (fromEnum a) = Just a
 
 checkBoundedEnum
-  ∷ ∀ eff a
+  ∷ ∀ a
   . Arbitrary a
   ⇒ BoundedEnum a
   ⇒ Ord a
   ⇒ Proxy a
-  → QC eff Unit
+  → Effect Unit
 checkBoundedEnum _ = do
 
   log "Checking 'succ' law for BoundedEnum"
@@ -58,7 +59,7 @@ checkBoundedEnum _ = do
   where
     c :: Int
     c = unwrap (cardinality :: Cardinality a)
-    
+
     succLaw :: Boolean
     succLaw = (Just top :: Maybe a) ==
                 foldl (>>=) (pure bottom) (replicate (c - 1) succ)
@@ -69,13 +70,13 @@ checkBoundedEnum _ = do
 
     predsuccLaw :: a -> Boolean
     predsuccLaw a = a == bottom || (pred a >>= succ) == Just a
-    
+
     succpredLaw :: a -> Boolean
     succpredLaw a = a == top || (succ a >>= pred) == Just a
 
     enumpredLaw :: a -> Boolean
     enumpredLaw a = a == bottom || (fromEnum <$> pred a) == Just (fromEnum a - 1)
-    
+
     enumsuccLaw :: a -> Boolean
     enumsuccLaw a = a == top || (fromEnum <$> succ a) == Just (fromEnum a + 1)
 

--- a/src/Test/QuickCheck/Laws/Data/CommutativeRing.purs
+++ b/src/Test/QuickCheck/Laws/Data/CommutativeRing.purs
@@ -2,21 +2,22 @@ module Test.QuickCheck.Laws.Data.CommutativeRing where
 
 import Prelude
 
-import Control.Monad.Eff.Console (log)
+import Effect (Effect)
+import Effect.Console (log)
 
 import Type.Proxy (Proxy)
 
-import Test.QuickCheck (QC, quickCheck')
+import Test.QuickCheck (quickCheck')
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 
 -- | - Commutative multiplication: `a * b = b * a`
 checkCommutativeRing
-  ∷ ∀ eff a
+  ∷ ∀ a
   . CommutativeRing a
   ⇒ Arbitrary a
   ⇒ Eq a
   ⇒ Proxy a
-  → QC eff Unit
+  → Effect Unit
 checkCommutativeRing _ = do
 
   log "Checking 'Commutative multiplication' law for CommutativeRing"

--- a/src/Test/QuickCheck/Laws/Data/Eq.purs
+++ b/src/Test/QuickCheck/Laws/Data/Eq.purs
@@ -2,11 +2,12 @@ module Test.QuickCheck.Laws.Data.Eq where
 
 import Prelude
 
-import Control.Monad.Eff.Console (log)
+import Effect (Effect)
+import Effect.Console (log)
 
 import Type.Proxy (Proxy)
 
-import Test.QuickCheck (QC, quickCheck')
+import Test.QuickCheck (quickCheck')
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 
 -- | - Reflexivity: `x == x = true`
@@ -14,11 +15,11 @@ import Test.QuickCheck.Arbitrary (class Arbitrary)
 -- | - Transitivity: if `x == y` and `y == z` then `x == z`
 -- | - Negation: `x /= y = not (x == y)`
 checkEq
-  ∷ ∀ eff a
+  ∷ ∀ a
   . Arbitrary a
   ⇒ Eq a
   ⇒ Proxy a
-  → QC eff Unit
+  → Effect Unit
 checkEq _ = do
 
   log "Checking 'Reflexivity' law for Eq"

--- a/src/Test/QuickCheck/Laws/Data/EuclideanRing.purs
+++ b/src/Test/QuickCheck/Laws/Data/EuclideanRing.purs
@@ -2,23 +2,24 @@ module Test.QuickCheck.Laws.Data.EuclideanRing where
 
 import Prelude
 
-import Control.Monad.Eff.Console (log)
+import Effect (Effect)
+import Effect.Console (log)
 
 import Type.Proxy (Proxy)
 
-import Test.QuickCheck (QC, quickCheck')
+import Test.QuickCheck (quickCheck')
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 
 -- | - Integral domain: `a /= 0` and `b /= 0` implies `a * b /= 0`
 -- | - Multiplicative Euclidean function: ``a = (a / b) * b + (a `mod` b)``
 -- |   where `degree a > 0` and `degree a <= degree (a * b)`
 checkEuclideanRing
-  ∷ ∀ eff a
+  ∷ ∀ a
   . EuclideanRing a
   ⇒ Arbitrary a
   ⇒ Eq a
   ⇒ Proxy a
-  → QC eff Unit
+  → Effect Unit
 checkEuclideanRing _ = do
 
   log "Checking 'Integral domain' law for EuclideanRing"

--- a/src/Test/QuickCheck/Laws/Data/Field.purs
+++ b/src/Test/QuickCheck/Laws/Data/Field.purs
@@ -2,21 +2,22 @@ module Test.QuickCheck.Laws.Data.Field where
 
 import Prelude
 
-import Control.Monad.Eff.Console (log)
+import Effect (Effect)
+import Effect.Console (log)
 
 import Type.Proxy (Proxy)
 
-import Test.QuickCheck (QC, quickCheck')
+import Test.QuickCheck (quickCheck')
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 
 -- | - Non-zero multiplicative inverse: ``a `mod` b = 0` for all `a` and `b`
 checkField
-  ∷ ∀ eff a
+  ∷ ∀ a
   . Field a
   ⇒ Arbitrary a
   ⇒ Eq a
   ⇒ Proxy a
-  → QC eff Unit
+  → Effect Unit
 checkField _ = do
 
   log "Checking 'Non-zero multiplicative inverse' law for Field"

--- a/src/Test/QuickCheck/Laws/Data/Foldable.purs
+++ b/src/Test/QuickCheck/Laws/Data/Foldable.purs
@@ -1,9 +1,10 @@
 module Test.QuickCheck.Laws.Data.Foldable where
 
 import Prelude
-import Control.Monad.Eff.Console (log)
+import Effect (Effect)
+import Effect.Console (log)
 import Data.Foldable (foldMap, fold, foldlDefault, foldl, foldr, class Foldable, foldrDefault)
-import Test.QuickCheck (QC, quickCheck')
+import Test.QuickCheck (quickCheck')
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 import Test.QuickCheck.Laws (A, B)
 import Type.Proxy (Proxy2)
@@ -12,11 +13,11 @@ import Type.Proxy (Proxy2)
 -- | - foldr: `foldr = foldrDefault`
 -- | - foldl: `foldl = foldlDefault`
 checkFoldable
-  ∷ ∀ eff f
+  ∷ ∀ f
   . Foldable f
   ⇒ Arbitrary (f A)
   ⇒ Proxy2 f
-  → QC eff Unit
+  → Effect Unit
 checkFoldable _ = do
 
   log "Checking 'foldr' law for Foldable"
@@ -31,16 +32,16 @@ checkFoldable _ = do
 
     foldlLaw :: (B -> A -> B) -> B -> f A -> Boolean
     foldlLaw f z t = foldl f z t == foldlDefault f z t
-                                                           
+
 
 -- | foldMap: `foldMap = fold <<< map`
 checkFoldableFunctor
-  ∷ ∀ eff f
+  ∷ ∀ f
   . Foldable f
   ⇒ Functor f
   ⇒ Arbitrary (f A)
   ⇒ Proxy2 f
-  → QC eff Unit
+  → Effect Unit
 checkFoldableFunctor ff = do
 
   checkFoldable ff

--- a/src/Test/QuickCheck/Laws/Data/Functor.purs
+++ b/src/Test/QuickCheck/Laws/Data/Functor.purs
@@ -2,35 +2,36 @@ module Test.QuickCheck.Laws.Data.Functor where
 
 import Prelude
 
-import Control.Monad.Eff.Console (log)
+import Effect (Effect)
+import Effect.Console (log)
 
 import Type.Proxy (Proxy2)
 
-import Test.QuickCheck (QC, quickCheck')
+import Test.QuickCheck (quickCheck')
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 import Test.QuickCheck.Laws (A, B)
 
--- | - Identity: `(<$>) id = id`
+-- | - Identity: `(<$>) identity = identity`
 -- | - Composition: `(<$>) (f <<< g) = (f <$>) <<< (g <$>)`
 checkFunctor
-  ∷ ∀ eff f
+  ∷ ∀ f
   . Functor f
   ⇒ Arbitrary (f A)
   ⇒ Eq (f A)
   ⇒ Proxy2 f
-  → QC eff Unit
+  → Effect Unit
 checkFunctor _ = do
 
   log "Checking 'Identity' law for Functor"
-  quickCheck' 1000 identity
+  quickCheck' 1000 identity'
 
   log "Checking 'Composition' law for Functor"
   quickCheck' 1000 composition
 
   where
 
-  identity ∷ f A → Boolean
-  identity f = (id <$> f) == id f
+  identity' ∷ f A → Boolean
+  identity' f = (identity <$> f) == identity f
 
   composition ∷ (B → A) → (A → B) → f A → Boolean
   composition f g x = ((<$>) (f <<< g) x) == (((f <$> _) <<< (g <$> _)) x)

--- a/src/Test/QuickCheck/Laws/Data/HeytingAlgebra.purs
+++ b/src/Test/QuickCheck/Laws/Data/HeytingAlgebra.purs
@@ -2,13 +2,14 @@ module Test.QuickCheck.Laws.Data.HeytingAlgebra where
 
 import Prelude
 
-import Control.Monad.Eff.Console (log)
+import Effect (Effect)
+import Effect.Console (log)
 
 import Data.HeytingAlgebra (tt, ff, implies)
 
 import Type.Proxy (Proxy)
 
-import Test.QuickCheck (QC, quickCheck')
+import Test.QuickCheck (quickCheck')
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 
 -- | - Associativity:
@@ -34,12 +35,12 @@ import Test.QuickCheck.Arbitrary (class Arbitrary)
 -- | - Complemented:
 -- |   - ``not a = a `implies` ff``
 checkHeytingAlgebra
-  ∷ ∀ eff a
+  ∷ ∀ a
   . Arbitrary a
   ⇒ HeytingAlgebra a
   ⇒ Eq a
   ⇒ Proxy a
-  → QC eff Unit
+  → Effect Unit
 checkHeytingAlgebra _ = do
 
   log "Checking 'Associativity of disjunction' law for HeytingAlgebra"

--- a/src/Test/QuickCheck/Laws/Data/Monoid.purs
+++ b/src/Test/QuickCheck/Laws/Data/Monoid.purs
@@ -2,24 +2,23 @@ module Test.QuickCheck.Laws.Data.Monoid where
 
 import Prelude
 
-import Control.Monad.Eff.Console (log)
-
-import Data.Monoid (class Monoid, mempty)
+import Effect (Effect)
+import Effect.Console (log)
 
 import Type.Proxy (Proxy)
 
-import Test.QuickCheck (QC, quickCheck')
+import Test.QuickCheck (quickCheck')
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 
 -- | - Left identity: `mempty <> x = x`
 -- | - Right identity: `x <> mempty = x`
 checkMonoid
-  ∷ ∀ eff m
+  ∷ ∀ m
   . Monoid m
   ⇒ Arbitrary m
   ⇒ Eq m
   ⇒ Proxy m
-  → QC eff Unit
+  → Effect Unit
 checkMonoid _ = do
 
   log "Checking 'Left identity' law for Monoid"

--- a/src/Test/QuickCheck/Laws/Data/Ord.purs
+++ b/src/Test/QuickCheck/Laws/Data/Ord.purs
@@ -2,22 +2,23 @@ module Test.QuickCheck.Laws.Data.Ord where
 
 import Prelude
 
-import Control.Monad.Eff.Console (log)
+import Effect (Effect)
+import Effect.Console (log)
 
 import Type.Proxy (Proxy)
 
-import Test.QuickCheck (QC, quickCheck')
+import Test.QuickCheck (quickCheck')
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 
 -- | - Reflexivity: `a <= a`
 -- | - Antisymmetry: if `a <= b` and `b <= a` then `a = b`
 -- | - Transitivity: if `a <= b` and `b <= c` then `a <= c`
 checkOrd
-  ∷ ∀ eff a
+  ∷ ∀ a
   . Arbitrary a
   ⇒ Ord a
   ⇒ Proxy a
-  → QC eff Unit
+  → Effect Unit
 checkOrd _ = do
 
   log "Checking 'Reflexivity' law for Ord"

--- a/src/Test/QuickCheck/Laws/Data/Ring.purs
+++ b/src/Test/QuickCheck/Laws/Data/Ring.purs
@@ -2,21 +2,22 @@ module Test.QuickCheck.Laws.Data.Ring where
 
 import Prelude
 
-import Control.Monad.Eff.Console (log)
+import Effect (Effect)
+import Effect.Console (log)
 
 import Type.Proxy (Proxy)
 
-import Test.QuickCheck (QC, quickCheck')
+import Test.QuickCheck (quickCheck')
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 
 -- | - Additive inverse: `a - a = a + (-a) = (-a) + a = zero`
 checkRing
-  ∷ ∀ eff a
+  ∷ ∀ a
   . Ring a
   ⇒ Arbitrary a
   ⇒ Eq a
   ⇒ Proxy a
-  → QC eff Unit
+  → Effect Unit
 checkRing _ = do
 
   log "Checking 'Additive inverse' law for Ring"

--- a/src/Test/QuickCheck/Laws/Data/Semigroup.purs
+++ b/src/Test/QuickCheck/Laws/Data/Semigroup.purs
@@ -2,21 +2,22 @@ module Test.QuickCheck.Laws.Data.Semigroup where
 
 import Prelude
 
-import Control.Monad.Eff.Console (log)
+import Effect (Effect)
+import Effect.Console (log)
 
 import Type.Proxy (Proxy)
 
-import Test.QuickCheck (QC, quickCheck')
+import Test.QuickCheck (quickCheck')
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 
 -- | - Associativity: `(x <> y) <> z = x <> (y <> z)`
 checkSemigroup
-  ∷ ∀ eff s
+  ∷ ∀ s
   . Semigroup s
   ⇒ Arbitrary s
   ⇒ Eq s
   ⇒ Proxy s
-  → QC eff Unit
+  → Effect Unit
 checkSemigroup _ = do
 
   log "Checking 'Associativity' law for Semigroup"

--- a/src/Test/QuickCheck/Laws/Data/Semiring.purs
+++ b/src/Test/QuickCheck/Laws/Data/Semiring.purs
@@ -2,11 +2,12 @@ module Test.QuickCheck.Laws.Data.Semiring where
 
 import Prelude
 
-import Control.Monad.Eff.Console (log)
+import Effect (Effect)
+import Effect.Console (log)
 
 import Type.Proxy (Proxy)
 
-import Test.QuickCheck (QC, quickCheck')
+import Test.QuickCheck (quickCheck')
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 
 -- | - Commutative monoid under addition:
@@ -21,12 +22,12 @@ import Test.QuickCheck.Arbitrary (class Arbitrary)
 -- |   - Right distributivity: `(a + b) * c = (a * c) + (b * c)`
 -- | - Annihiliation: `zero * a = a * zero = zero`
 checkSemiring
-  ∷ ∀ eff a
+  ∷ ∀ a
   . Semiring a
   ⇒ Arbitrary a
   ⇒ Eq a
   ⇒ Proxy a
-  → QC eff Unit
+  → Effect Unit
 checkSemiring _ = do
 
   log "Checking 'Associativity' law for Semiring addition"

--- a/test/Test/Data/Either.purs
+++ b/test/Test/Data/Either.purs
@@ -2,22 +2,23 @@ module Test.Data.Either where
 
 import Prelude
 
+import Effect (Effect)
 import Data.Either (Either)
 
-import Test.QuickCheck.Laws (QC, A, B, C, checkLaws)
+import Test.QuickCheck.Laws (A, B, C, checkLaws)
 import Test.QuickCheck.Laws.Control as Control
 import Test.QuickCheck.Laws.Data as Data
 
 import Type.Proxy (Proxy(..), Proxy2(..))
 
-checkEither ∷ ∀ eff. QC eff Unit
+checkEither ∷ Effect Unit
 checkEither = checkLaws "Either" do
   Data.checkEq prxEither
   Data.checkOrd prxEither
   Data.checkBounded prxEither
   Data.checkBoundedEnum prxEither
   Data.checkFunctor prx2Either
-  Data.checkFoldableFunctor prx2Either  
+  Data.checkFoldableFunctor prx2Either
   Control.checkApply prx2Either
   Control.checkApplicative prx2Either
   Control.checkAlt prx2Either

--- a/test/Test/Data/Either.purs
+++ b/test/Test/Data/Either.purs
@@ -16,7 +16,6 @@ checkEither = checkLaws "Either" do
   Data.checkEq prxEither
   Data.checkOrd prxEither
   Data.checkBounded prxEither
-  Data.checkBoundedEnum prxEither
   Data.checkFunctor prx2Either
   Data.checkFoldableFunctor prx2Either
   Control.checkApply prx2Either

--- a/test/Test/Data/Identity.purs
+++ b/test/Test/Data/Identity.purs
@@ -2,15 +2,16 @@ module Test.Data.Identity where
 
 import Prelude
 
+import Effect (Effect)
 import Data.Identity (Identity)
 
-import Test.QuickCheck.Laws (QC, A, checkLaws)
+import Test.QuickCheck.Laws (A, checkLaws)
 import Test.QuickCheck.Laws.Control as Control
 import Test.QuickCheck.Laws.Data as Data
 
 import Type.Proxy (Proxy(..), Proxy2(..))
 
-checkIdentity ∷ ∀ eff. QC eff Unit
+checkIdentity ∷ Effect Unit
 checkIdentity = checkLaws "Identity" do
   Data.checkEq prxIdentity
   Data.checkOrd prxIdentity
@@ -26,7 +27,7 @@ checkIdentity = checkLaws "Identity" do
   -- Data.checkField prxIdentity
 
   Data.checkFunctor prx2Identity
-  Data.checkFoldableFunctor prx2Identity  
+  Data.checkFoldableFunctor prx2Identity
   Control.checkApply prx2Identity
   Control.checkApplicative prx2Identity
   Control.checkBind prx2Identity

--- a/test/Test/Data/List.purs
+++ b/test/Test/Data/List.purs
@@ -4,18 +4,20 @@ import Prelude
 
 import Data.List (List)
 
-import Test.QuickCheck.Laws (QC, A, checkLaws)
+import Effect (Effect)
+
+import Test.QuickCheck.Laws (A, checkLaws)
 import Test.QuickCheck.Laws.Control as Control
 import Test.QuickCheck.Laws.Data as Data
 
 import Type.Proxy (Proxy(..), Proxy2(..))
 
-checkList ∷ ∀ eff. QC eff Unit
+checkList ∷ Effect Unit
 checkList = checkLaws "List" do
   Data.checkEq prxList
   Data.checkOrd prxList
   Data.checkFunctor prx2List
-  Data.checkFoldableFunctor prx2List  
+  Data.checkFoldableFunctor prx2List
   Control.checkApply prx2List
   Control.checkApplicative prx2List
   Control.checkBind prx2List

--- a/test/Test/Data/Maybe.purs
+++ b/test/Test/Data/Maybe.purs
@@ -4,13 +4,15 @@ import Prelude
 
 import Data.Maybe (Maybe)
 
-import Test.QuickCheck.Laws (QC, A, checkLaws)
+import Effect (Effect)
+
+import Test.QuickCheck.Laws (A, checkLaws)
 import Test.QuickCheck.Laws.Control as Control
 import Test.QuickCheck.Laws.Data as Data
 
 import Type.Proxy (Proxy(..), Proxy2(..))
 
-checkMaybe ∷ ∀ eff. QC eff Unit
+checkMaybe ∷ Effect Unit
 checkMaybe = checkLaws "Maybe" do
   Data.checkEq prxMaybe
   Data.checkOrd prxMaybe
@@ -19,7 +21,7 @@ checkMaybe = checkLaws "Maybe" do
   Data.checkSemigroup prxMaybe
   Data.checkMonoid prxMaybe
   Data.checkFunctor prx2Maybe
-  Data.checkFoldableFunctor prx2Maybe  
+  Data.checkFoldableFunctor prx2Maybe
   Control.checkApply prx2Maybe
   Control.checkApplicative prx2Maybe
   Control.checkAlt prx2Maybe

--- a/test/Test/Data/Maybe.purs
+++ b/test/Test/Data/Maybe.purs
@@ -17,7 +17,6 @@ checkMaybe = checkLaws "Maybe" do
   Data.checkEq prxMaybe
   Data.checkOrd prxMaybe
   Data.checkBounded prxMaybe
-  Data.checkBoundedEnum prxMaybe
   Data.checkSemigroup prxMaybe
   Data.checkMonoid prxMaybe
   Data.checkFunctor prx2Maybe

--- a/test/Test/Data/Ordering.purs
+++ b/test/Test/Data/Ordering.purs
@@ -2,12 +2,14 @@ module Test.Data.Ordering where
 
 import Prelude
 
-import Test.QuickCheck.Laws (QC, checkLaws)
+import Effect (Effect)
+
+import Test.QuickCheck.Laws (checkLaws)
 import Test.QuickCheck.Laws.Data as Data
 
 import Type.Proxy (Proxy(..))
 
-checkOrdering ∷ ∀ eff. QC eff Unit
+checkOrdering ∷ Effect Unit
 checkOrdering = checkLaws "Ordering" do
   Data.checkEq prxOrdering
   Data.checkOrd prxOrdering

--- a/test/Test/Data/Tuple.purs
+++ b/test/Test/Data/Tuple.purs
@@ -4,13 +4,15 @@ import Prelude
 
 import Data.Tuple (Tuple)
 
-import Test.QuickCheck.Laws (QC, A, B, C, checkLaws)
+import Effect (Effect)
+
+import Test.QuickCheck.Laws (A, B, C, checkLaws)
 import Test.QuickCheck.Laws.Control as Control
 import Test.QuickCheck.Laws.Data as Data
 
 import Type.Proxy (Proxy(..), Proxy2(..), Proxy3(..))
 
-checkTuple ∷ ∀ eff. QC eff Unit
+checkTuple ∷ Effect Unit
 checkTuple = checkLaws "Tuple" do
   Data.checkEq prxTuple
   Data.checkOrd prxTuple
@@ -19,7 +21,7 @@ checkTuple = checkLaws "Tuple" do
   Data.checkSemigroup prxTuple
   Data.checkMonoid prxTuple
   Data.checkFunctor prx2Tuple
-  Data.checkFoldableFunctor prx2Tuple  
+  Data.checkFoldableFunctor prx2Tuple
   Control.checkSemigroupoid prx3Tuple
   Control.checkApply prx2Tuple
   Control.checkApplicative prx2Tuple

--- a/test/Test/Data/Tuple.purs
+++ b/test/Test/Data/Tuple.purs
@@ -17,7 +17,6 @@ checkTuple = checkLaws "Tuple" do
   Data.checkEq prxTuple
   Data.checkOrd prxTuple
   Data.checkBounded prxTuple
-  Data.checkBoundedEnum prxTuple
   Data.checkSemigroup prxTuple
   Data.checkMonoid prxTuple
   Data.checkFunctor prx2Tuple

--- a/test/Test/Data/Unit.purs
+++ b/test/Test/Data/Unit.purs
@@ -2,12 +2,13 @@ module Test.Data.Unit where
 
 import Prelude
 
-import Test.QuickCheck.Laws (QC, checkLaws)
-import Test.QuickCheck.Laws.Data as Data
+import Effect (Effect)
 
+import Test.QuickCheck.Laws (checkLaws)
+import Test.QuickCheck.Laws.Data as Data
 import Type.Proxy (Proxy(..))
 
-checkUnit ∷ ∀ eff. QC eff Unit
+checkUnit ∷ Effect Unit
 checkUnit = checkLaws "Unit" do
   Data.checkEq prxUnit
   Data.checkOrd prxUnit

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -2,7 +2,7 @@ module Test.Main where
 
 import Prelude
 
-import Test.QuickCheck (QC)
+import Effect (Effect)
 import Test.Data.Either (checkEither)
 import Test.Data.Identity (checkIdentity)
 import Test.Data.List (checkList)
@@ -16,7 +16,7 @@ import Test.Prim.Int (checkInt)
 import Test.Prim.Number (checkNumber)
 import Test.Prim.String (checkString)
 
-main ∷ QC () Unit
+main ∷ Effect Unit
 main = do
   checkArray
   checkBoolean

--- a/test/Test/Prim/Array.purs
+++ b/test/Test/Prim/Array.purs
@@ -2,13 +2,14 @@ module Test.Prim.Array where
 
 import Prelude
 
-import Test.QuickCheck.Laws (QC, A, checkLaws)
+import Effect (Effect)
+
+import Test.QuickCheck.Laws (A, checkLaws)
 import Test.QuickCheck.Laws.Control as Control
 import Test.QuickCheck.Laws.Data as Data
-
 import Type.Proxy (Proxy(..), Proxy2(..))
 
-checkArray ∷ ∀ eff. QC eff Unit
+checkArray ∷ Effect Unit
 checkArray = checkLaws "Array" do
   Data.checkEq prxArray
   Data.checkOrd prxArray

--- a/test/Test/Prim/Boolean.purs
+++ b/test/Test/Prim/Boolean.purs
@@ -2,12 +2,13 @@ module Test.Prim.Boolean where
 
 import Prelude
 
-import Test.QuickCheck.Laws (QC, checkLaws)
-import Test.QuickCheck.Laws.Data as Data
+import Effect (Effect)
 
+import Test.QuickCheck.Laws (checkLaws)
+import Test.QuickCheck.Laws.Data as Data
 import Type.Proxy (Proxy(..))
 
-checkBoolean ∷ ∀ eff. QC eff Unit
+checkBoolean ∷ Effect Unit
 checkBoolean = checkLaws "Boolean" do
   Data.checkEq prxBoolean
   Data.checkOrd prxBoolean

--- a/test/Test/Prim/Int.purs
+++ b/test/Test/Prim/Int.purs
@@ -2,12 +2,13 @@ module Test.Prim.Int where
 
 import Prelude
 
-import Test.QuickCheck.Laws (QC, checkLaws)
-import Test.QuickCheck.Laws.Data as Data
+import Effect (Effect)
 
+import Test.QuickCheck.Laws (checkLaws)
+import Test.QuickCheck.Laws.Data as Data
 import Type.Proxy (Proxy(..))
 
-checkInt ∷ ∀ eff. QC eff Unit
+checkInt ∷ Effect Unit
 checkInt = checkLaws "Int" do
   Data.checkEq prxInt
   Data.checkOrd prxInt

--- a/test/Test/Prim/Number.purs
+++ b/test/Test/Prim/Number.purs
@@ -41,4 +41,4 @@ derive newtype instance semiringApproxNumber :: Semiring ApproxNumber
 derive newtype instance ringApproxNumber :: Ring ApproxNumber
 derive newtype instance commutativeRingApproxNumber :: CommutativeRing ApproxNumber
 derive newtype instance euclideanRingApproxNumber :: EuclideanRing ApproxNumber
-derive newtype instance fieldApproxNumber :: Field ApproxNumber
+derive newtype instance divisionRingApproxNumber :: DivisionRing ApproxNumber

--- a/test/Test/Prim/Number.purs
+++ b/test/Test/Prim/Number.purs
@@ -2,13 +2,14 @@ module Test.Prim.Number where
 
 import Prelude
 
-import Test.QuickCheck.Arbitrary (class Coarbitrary, class Arbitrary)
-import Test.QuickCheck.Laws (QC, checkLaws)
-import Test.QuickCheck.Laws.Data as Data
+import Effect (Effect)
 
+import Test.QuickCheck.Arbitrary (class Coarbitrary, class Arbitrary)
+import Test.QuickCheck.Laws (checkLaws)
+import Test.QuickCheck.Laws.Data as Data
 import Type.Proxy (Proxy(..))
 
-checkNumber ∷ ∀ eff. QC eff Unit
+checkNumber ∷ Effect Unit
 checkNumber = checkLaws "Number" do
   Data.checkEq prxNumber
   Data.checkOrd prxNumber

--- a/test/Test/Prim/String.purs
+++ b/test/Test/Prim/String.purs
@@ -2,12 +2,14 @@ module Test.Prim.String where
 
 import Prelude
 
-import Test.QuickCheck.Laws (QC, checkLaws)
+import Effect (Effect)
+
+import Test.QuickCheck.Laws (checkLaws)
 import Test.QuickCheck.Laws.Data as Data
 
 import Type.Proxy (Proxy(..))
 
-checkString ∷ ∀ eff. QC eff Unit
+checkString ∷ Effect Unit
 checkString = checkLaws "String" do
   Data.checkEq prxString
   Data.checkOrd prxString


### PR DESCRIPTION
Hi Gary!

Now that the new version of the compiler is out, we're updating several of our libraries and applications at CitizenNet to use it. We rely on this repository in our code, so I've gone through and updated the package to work with the latest versions.

This pull request bumps all dependencies to their 0.12-compatible versions and verifies the package is compatible. The library now builds successfully.

I'd love to see an update soon, as some of our open-source libraries rely on this as do other popular libraries in the ecosystem like `big-int`:
https://github.com/sharkdp/purescript-bigints/pull/20

**Edit: See below, this is fixed.**
Test, though, are a different story! Attempting to run them produces a few errors. I'm off to lunch, but I can come back and take a stab at fixing these when I return. I wanted to leave this as a WIP just in case you know a quick solution to each of these, otherwise I'll come back and work on it myself!

Cheers,
Thomas

```sh
Error 1 of 4:

  in module Test.Data.Either
  at test/Test/Data/Either.purs line 19, column 3 - line 19, column 34

    No type class instance was found for

      Data.Enum.BoundedEnum (Either A B)


  while applying a function checkBoundedEnum
    of type Arbitrary t2 => BoundedEnum t2 => Ord t2 => Proxy t2 -> Effect Unit
    to argument prxEither
  while checking that expression checkBoundedEnum prxEither
    has type t0 t1
  in value declaration checkEither

  where t1 is an unknown type
        t0 is an unknown type
        t2 is an unknown type

  See https://github.com/purescript/documentation/blob/master/errors/NoInstanceFound.md for more information,
  or to contribute content related to this error.

Error 2 of 4:

  in module Test.Data.Maybe
  at test/Test/Data/Maybe.purs line 20, column 3 - line 20, column 33

    No type class instance was found for

      Data.Enum.BoundedEnum (Maybe A)


  while applying a function checkBoundedEnum
    of type Arbitrary t2 => BoundedEnum t2 => Ord t2 => Proxy t2 -> Effect Unit
    to argument prxMaybe
  while checking that expression checkBoundedEnum prxMaybe
    has type t0 t1
  in value declaration checkMaybe

  where t1 is an unknown type
        t0 is an unknown type
        t2 is an unknown type

  See https://github.com/purescript/documentation/blob/master/errors/NoInstanceFound.md for more information,
  or to contribute content related to this error.

Error 3 of 4:

  in module Test.Data.Tuple
  at test/Test/Data/Tuple.purs line 20, column 3 - line 20, column 33

    No type class instance was found for

      Data.Enum.BoundedEnum (Tuple A B)


  while applying a function checkBoundedEnum
    of type Arbitrary t2 => BoundedEnum t2 => Ord t2 => Proxy t2 -> Effect Unit
    to argument prxTuple
  while checking that expression checkBoundedEnum prxTuple
    has type t0 t1
  in value declaration checkTuple

  where t1 is an unknown type
        t0 is an unknown type
        t2 is an unknown type

  See https://github.com/purescript/documentation/blob/master/errors/NoInstanceFound.md for more information,
  or to contribute content related to this error.

Error 4 of 4:

  in module Test.Prim.Number
  at test/Test/Prim/Number.purs line 44, column 16 - line 44, column 52

    Overlapping type class instances found for

      Data.Field.Field ApproxNumber

    The following instances were found:

      Data.Field.field
      Test.Prim.Number.fieldApproxNumber


  in type class instance

    Data.Field.Field ApproxNumber


  See https://github.com/purescript/documentation/blob/master/errors/OverlappingInstances.md for more information,
  or to contribute content related to this error.
```

