### PR TITLE
Alternative functions for better error reporting

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "purescript-proxy": "^3.0.0",
     "purescript-enums": "^4.0.0",
-    "purescript-quickcheck": "^5.0.0"
+    "purescript-quickcheck": "^5.0.0",
+    "purescript-quickcheck-combinators": "^0.1.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -23,6 +23,6 @@
     "purescript-proxy": "^3.0.0",
     "purescript-enums": "^4.0.0",
     "purescript-quickcheck": "^5.0.0",
-    "purescript-quickcheck-combinators": "^0.1.0"
+    "purescript-quickcheck-combinators": "^0.1.1"
   }
 }

--- a/src/Test/QuickCheck/Laws.purs
+++ b/src/Test/QuickCheck/Laws.purs
@@ -23,6 +23,7 @@ derive newtype instance boundedEnumA :: BoundedEnum A
 derive newtype instance coarbitraryA ∷ Coarbitrary A
 derive newtype instance eqA ∷ Eq A
 derive newtype instance ordA ∷ Ord A
+derive newtype instance showA ∷ Show A
 derive newtype instance semigroupA ∷ Semigroup A
 instance monoidA ∷ Monoid A where mempty = A EQ
 
@@ -35,6 +36,7 @@ derive newtype instance boundedEnumB :: BoundedEnum B
 derive newtype instance coarbitraryB ∷ Coarbitrary B
 derive newtype instance eqB ∷ Eq B
 derive newtype instance ordB ∷ Ord B
+derive newtype instance showB ∷ Show B
 derive newtype instance semigroupB ∷ Semigroup B
 instance monoidB ∷ Monoid B where mempty = B EQ
 
@@ -47,6 +49,7 @@ derive newtype instance boundedEnumC :: BoundedEnum C
 derive newtype instance coarbitraryC ∷ Coarbitrary C
 derive newtype instance eqC ∷ Eq C
 derive newtype instance ordC ∷ Ord C
+derive newtype instance showC ∷ Show C
 derive newtype instance semigroupC ∷ Semigroup C
 instance monoidC ∷ Monoid C where mempty = C EQ
 
@@ -59,6 +62,7 @@ derive newtype instance boundedEnumD :: BoundedEnum D
 derive newtype instance coarbitraryD ∷ Coarbitrary D
 derive newtype instance eqD ∷ Eq D
 derive newtype instance ordD ∷ Ord D
+derive newtype instance showD ∷ Show D
 derive newtype instance semigroupD ∷ Semigroup D
 instance monoidD ∷ Monoid D where mempty = D EQ
 
@@ -71,5 +75,6 @@ derive newtype instance boundedEnumE :: BoundedEnum E
 derive newtype instance coarbitraryE ∷ Coarbitrary E
 derive newtype instance eqE ∷ Eq E
 derive newtype instance ordE ∷ Ord E
+derive newtype instance showE ∷ Show E
 derive newtype instance semigroupE ∷ Semigroup E
 instance monoidE ∷ Monoid E where mempty = E EQ

--- a/src/Test/QuickCheck/Laws/Control.purs
+++ b/src/Test/QuickCheck/Laws/Control.purs
@@ -1,15 +1,15 @@
 module Test.QuickCheck.Laws.Control (module Exports) where
 
-import Test.QuickCheck.Laws.Control.Alt (checkAlt) as Exports
-import Test.QuickCheck.Laws.Control.Alternative (checkAlternative) as Exports
-import Test.QuickCheck.Laws.Control.Applicative (checkApplicative) as Exports
-import Test.QuickCheck.Laws.Control.Apply (checkApply) as Exports
-import Test.QuickCheck.Laws.Control.Bind (checkBind) as Exports
-import Test.QuickCheck.Laws.Control.Category (checkCategory) as Exports
-import Test.QuickCheck.Laws.Control.Comonad (checkComonad) as Exports
-import Test.QuickCheck.Laws.Control.Extend (checkExtend) as Exports
-import Test.QuickCheck.Laws.Control.Monad (checkMonad) as Exports
-import Test.QuickCheck.Laws.Control.MonadPlus (checkMonadPlus) as Exports
-import Test.QuickCheck.Laws.Control.MonadZero (checkMonadZero) as Exports
-import Test.QuickCheck.Laws.Control.Plus (checkPlus) as Exports
-import Test.QuickCheck.Laws.Control.Semigroupoid (checkSemigroupoid) as Exports
+import Test.QuickCheck.Laws.Control.Alt (checkAlt, checkAltShow) as Exports
+import Test.QuickCheck.Laws.Control.Alternative (checkAlternative, checkAlternativeShow) as Exports
+import Test.QuickCheck.Laws.Control.Applicative (checkApplicative, checkApplicativeShow) as Exports
+import Test.QuickCheck.Laws.Control.Apply (checkApply, checkApplyShow) as Exports
+import Test.QuickCheck.Laws.Control.Bind (checkBind, checkBindShow) as Exports
+import Test.QuickCheck.Laws.Control.Category (checkCategory, checkCategoryShow) as Exports
+import Test.QuickCheck.Laws.Control.Comonad (checkComonad, checkComonadShow) as Exports
+import Test.QuickCheck.Laws.Control.Extend (checkExtend, checkExtendShow) as Exports
+import Test.QuickCheck.Laws.Control.Monad (checkMonad, checkMonadShow) as Exports
+import Test.QuickCheck.Laws.Control.MonadPlus (checkMonadPlus, checkMonadPlusShow) as Exports
+import Test.QuickCheck.Laws.Control.MonadZero (checkMonadZero, checkMonadZeroShow) as Exports
+import Test.QuickCheck.Laws.Control.Plus (checkPlus, checkPlusShow) as Exports
+import Test.QuickCheck.Laws.Control.Semigroupoid (checkSemigroupoid, checkSemigroupoidShow) as Exports

--- a/src/Test/QuickCheck/Laws/Control/Alt.purs
+++ b/src/Test/QuickCheck/Laws/Control/Alt.purs
@@ -5,7 +5,7 @@ import Prelude
 import Control.Alt (class Alt, (<|>))
 import Effect (Effect)
 import Effect.Console (log)
-import Test.QuickCheck (quickCheck')
+import Test.QuickCheck (quickCheck', Result, (===))
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 import Test.QuickCheck.Laws (A, B)
 import Type.Proxy (Proxy2)
@@ -35,3 +35,33 @@ checkAlt _ = do
 
   distributivity ∷ (A → B) → f A → f A → Boolean
   distributivity f x y = (f <$> (x <|> y)) == ((f <$> x) <|> (f <$> y))
+
+
+-- | Like `checkAlt`, but with better error reporting.
+-- | - Associativity: `(x <|> y) <|> z == x <|> (y <|> z)`
+-- | - Distributivity: `f <$> (x <|> y) == (f <$> x) <|> (f <$> y)`
+checkAltShow
+  ∷ ∀ f
+  . Alt f
+  ⇒ Arbitrary (f A)
+  ⇒ Eq (f A)
+  ⇒ Eq (f B)
+  ⇒ Show (f A)
+  ⇒ Show (f B)
+  ⇒ Proxy2 f
+  → Effect Unit
+checkAltShow _ = do
+
+  log "Checking 'Associativity' law for Alt"
+  quickCheck' 1000 associativity
+
+  log "Checking 'Distributivity' law for Alt"
+  quickCheck' 1000 distributivity
+
+  where
+
+  associativity ∷ f A → f A → f A → Result
+  associativity x y z = ((x <|> y) <|> z) === (x <|> (y <|> z))
+
+  distributivity ∷ (A → B) → f A → f A → Result
+  distributivity f x y = (f <$> (x <|> y)) === ((f <$> x) <|> (f <$> y))

--- a/src/Test/QuickCheck/Laws/Control/Applicative.purs
+++ b/src/Test/QuickCheck/Laws/Control/Applicative.purs
@@ -5,7 +5,7 @@ import Prelude
 import Data.Function as F
 import Effect (Effect)
 import Effect.Console (log)
-import Test.QuickCheck (quickCheck')
+import Test.QuickCheck (quickCheck', Result, (===))
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 import Test.QuickCheck.Laws (A, B, C)
 import Type.Proxy (Proxy2)
@@ -52,3 +52,51 @@ checkApplicative _ = do
 
   interchange ∷ A → f (A → B) → Boolean
   interchange y u = (u <*> pure y) == (pure (_ $ y) <*> u)
+
+
+-- | Like `checkApplicative`, but with better error reporting.
+-- | - Identity: `(pure identity) <*> v = v`
+-- | - Composition: `(pure (<<<)) <*> f <*> g <*> h = f <*> (g <*> h)`
+-- | - Homomorphism: `(pure f) <*> (pure x) = pure (f x)`
+-- | - Interchange: `u <*> (pure y) = (pure ($ y)) <*> u`
+checkApplicativeShow
+  ∷ ∀ f
+  . Applicative f
+  ⇒ Arbitrary (f A)
+  ⇒ Arbitrary (f (A → B))
+  ⇒ Arbitrary (f (B → C))
+  ⇒ Eq (f A)
+  ⇒ Eq (f B)
+  ⇒ Eq (f C)
+  ⇒ Show (f A)
+  ⇒ Show (f B)
+  ⇒ Show (f C)
+  ⇒ Proxy2 f
+  → Effect Unit
+checkApplicativeShow _ = do
+
+  log "Checking 'Identity' law for Applicative"
+  quickCheck' 1000 identity
+
+  log "Checking 'Composition' law for Applicative"
+  quickCheck' 1000 composition
+
+  log "Checking 'Homomorphism' law for Applicative"
+  quickCheck' 1000 homomorphism
+
+  log "Checking 'Interchange' law for Applicative"
+  quickCheck' 1000 interchange
+
+  where
+
+  identity ∷ f A → Result
+  identity v = (pure F.identity <*> v) === v
+
+  composition ∷ f (B → C) → f (A → B) → f A → Result
+  composition f g x = (pure (<<<) <*> f <*> g <*> x) === (f <*> (g <*> x))
+
+  homomorphism ∷ (A → B) → A → Result
+  homomorphism f x = (pure f <*> pure x) === (pure (f x) ∷ f B)
+
+  interchange ∷ A → f (A → B) → Result
+  interchange y u = (u <*> pure y) === (pure (_ $ y) <*> u)

--- a/src/Test/QuickCheck/Laws/Control/Apply.purs
+++ b/src/Test/QuickCheck/Laws/Control/Apply.purs
@@ -4,7 +4,7 @@ import Prelude
 
 import Effect (Effect)
 import Effect.Console (log)
-import Test.QuickCheck (quickCheck')
+import Test.QuickCheck (quickCheck', Result, (===))
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 import Test.QuickCheck.Laws (A, B, C)
 import Type.Proxy (Proxy2)
@@ -28,3 +28,26 @@ checkApply _ = do
 
   associativeComposition ∷ f (B → C) → f (A → B) → f A → Boolean
   associativeComposition f g x = ((<<<) <$> f <*> g <*> x) == (f <*> (g <*> x))
+
+
+-- | Like `checkApply`, but with better error reporting.
+-- | - Associative composition: `(<<<) <$> f <*> g <*> h = f <*> (g <*> h)`
+checkApplyShow
+  ∷ ∀ f
+  . Apply f
+  ⇒ Arbitrary (f A)
+  ⇒ Arbitrary (f (A → B))
+  ⇒ Arbitrary (f (B → C))
+  ⇒ Eq (f C)
+  ⇒ Show (f C)
+  ⇒ Proxy2 f
+  → Effect Unit
+checkApplyShow _ = do
+
+  log "Checking 'Associative composition' law for Apply"
+  quickCheck' 1000 associativeComposition
+
+  where
+
+  associativeComposition ∷ f (B → C) → f (A → B) → f A → Result
+  associativeComposition f g x = ((<<<) <$> f <*> g <*> x) === (f <*> (g <*> x))

--- a/src/Test/QuickCheck/Laws/Control/Bind.purs
+++ b/src/Test/QuickCheck/Laws/Control/Bind.purs
@@ -4,7 +4,7 @@ import Prelude
 
 import Effect (Effect)
 import Effect.Console (log)
-import Test.QuickCheck (quickCheck')
+import Test.QuickCheck (quickCheck', Result, (===))
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 import Test.QuickCheck.Laws (A)
 import Type.Proxy (Proxy2)
@@ -26,3 +26,24 @@ checkBind _ = do
 
   associativity ∷ m A → (A → m A) → (A → m A) → Boolean
   associativity m f g = ((m >>= f) >>= g) == (m >>= (\x → f x >>= g))
+
+
+-- | Like `checkBind`, but with better error reporting
+-- | - Associativity: `(x >>= f) >>= g = x >>= (\k → f k >>= g)`
+checkBindShow
+  ∷ ∀ m
+  . Bind m
+  ⇒ Arbitrary (m A)
+  ⇒ Eq (m A)
+  ⇒ Show (m A)
+  ⇒ Proxy2 m
+  → Effect Unit
+checkBindShow _ = do
+
+  log "Checking 'Associativity' law for Bind"
+  quickCheck' 1000 associativity
+
+  where
+
+  associativity ∷ m A → (A → m A) → (A → m A) → Result
+  associativity m f g = ((m >>= f) >>= g) === (m >>= (\x → f x >>= g))

--- a/src/Test/QuickCheck/Laws/Control/Category.purs
+++ b/src/Test/QuickCheck/Laws/Control/Category.purs
@@ -5,7 +5,8 @@ import Prelude
 import Data.Function as F
 import Effect (Effect)
 import Effect.Console (log)
-import Test.QuickCheck (quickCheck')
+import Test.QuickCheck (quickCheck', Result, (===))
+import Test.QuickCheck.Combinators ((&=&))
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 import Test.QuickCheck.Laws (B, C)
 import Type.Proxy (Proxy3)
@@ -28,3 +29,24 @@ checkCategory _ = do
   identity ∷ a B C → Boolean
   identity p = (F.identity <<< p) == p
             && (p <<< F.identity) == p
+
+
+-- | - Identity: `id <<< p = p <<< id = p`
+checkCategoryShow
+  ∷ ∀ a
+  . Category a
+  ⇒ Arbitrary (a B C)
+  ⇒ Eq (a B C)
+  ⇒ Show (a B C)
+  ⇒ Proxy3 a
+  → Effect Unit
+checkCategoryShow _ = do
+
+  log "Checking 'Identity' law for Category"
+  quickCheck' 1000 identity
+
+  where
+
+  identity ∷ a B C → Result
+  identity p = ((F.identity <<< p) === p)
+           &=& ((p <<< F.identity) === p)

--- a/src/Test/QuickCheck/Laws/Control/Comonad.purs
+++ b/src/Test/QuickCheck/Laws/Control/Comonad.purs
@@ -6,7 +6,7 @@ import Control.Comonad (class Comonad, extract)
 import Control.Extend ((<<=))
 import Effect (Effect)
 import Effect.Console (log)
-import Test.QuickCheck (quickCheck')
+import Test.QuickCheck (quickCheck', Result, (===))
 import Test.QuickCheck.Arbitrary (class Arbitrary, class Coarbitrary)
 import Test.QuickCheck.Laws (A, B)
 import Type.Proxy (Proxy2)
@@ -36,3 +36,32 @@ checkComonad _ = do
 
   rightIdentity ∷ (w A → B) → w A → Boolean
   rightIdentity f x = extract (f <<= x) == f x
+
+
+-- | Like `checkComonad`, but with better error reporting.
+-- | - Left Identity: `extract <<= x = x`
+-- | - Right Identity: `extract (f <<= x) = f x`
+checkComonadShow
+  ∷ ∀ w
+  . Comonad w
+  ⇒ Arbitrary (w A)
+  ⇒ Coarbitrary (w A)
+  ⇒ Eq (w A)
+  ⇒ Show (w A)
+  ⇒ Proxy2 w
+  → Effect Unit
+checkComonadShow _ = do
+
+  log "Checking 'Left identity' law for Comonad"
+  quickCheck' 1000 leftIdentity
+
+  log "Checking 'Right identity' law for Comonad"
+  quickCheck' 1000 rightIdentity
+
+  where
+
+  leftIdentity ∷ w A → Result
+  leftIdentity x = (extract <<= x) === x
+
+  rightIdentity ∷ (w A → B) → w A → Result
+  rightIdentity f x = extract (f <<= x) === f x

--- a/src/Test/QuickCheck/Laws/Control/Extend.purs
+++ b/src/Test/QuickCheck/Laws/Control/Extend.purs
@@ -5,7 +5,7 @@ import Prelude
 import Control.Extend (class Extend, (<<=))
 import Effect (Effect)
 import Effect.Console (log)
-import Test.QuickCheck (quickCheck')
+import Test.QuickCheck (quickCheck', Result, (===))
 import Test.QuickCheck.Arbitrary (class Arbitrary, class Coarbitrary)
 import Test.QuickCheck.Laws (A, B, C)
 import Type.Proxy (Proxy2)
@@ -30,3 +30,27 @@ checkExtend _ = do
   associativity ∷ (w B → C) → (w A → B) → w A → Boolean
   associativity f g x =
     ((f <<= _) <<< (g <<= _) $ x) == (f <<< (g <<= _) <<= x)
+
+
+-- | Like `checkExtend`, but with better error reporting.
+-- | - Associativity: `extend f <<< extend g = extend (f <<< extend g)`
+checkExtendShow
+  ∷ ∀ w
+  . Extend w
+  ⇒ Arbitrary (w A)
+  ⇒ Coarbitrary (w A)
+  ⇒ Coarbitrary (w B)
+  ⇒ Eq (w C)
+  ⇒ Show (w C)
+  ⇒ Proxy2 w
+  → Effect Unit
+checkExtendShow _ = do
+
+  log "Checking 'Associativity' law for Extend"
+  quickCheck' 1000 associativity
+
+  where
+
+  associativity ∷ (w B → C) → (w A → B) → w A → Result
+  associativity f g x =
+    ((f <<= _) <<< (g <<= _) $ x) === (f <<< (g <<= _) <<= x)

--- a/src/Test/QuickCheck/Laws/Control/Monad.purs
+++ b/src/Test/QuickCheck/Laws/Control/Monad.purs
@@ -4,7 +4,7 @@ import Prelude
 
 import Effect (Effect)
 import Effect.Console (log)
-import Test.QuickCheck (quickCheck')
+import Test.QuickCheck (quickCheck', Result, (===))
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 import Test.QuickCheck.Laws (A)
 import Type.Proxy (Proxy2)
@@ -33,3 +33,31 @@ checkMonad _ = do
 
   rightIdentity ∷ m A → Boolean
   rightIdentity m = (m >>= pure) == m
+
+
+-- | Like `checkMonad`, but with better error reporting.
+-- | - Left Identity: `pure x >>= f = f x`
+-- | - Right Identity: `x >>= pure = x`
+checkMonadShow
+  ∷ ∀ m
+  . Monad m
+  ⇒ Arbitrary (m A)
+  ⇒ Eq (m A)
+  ⇒ Show (m A)
+  ⇒ Proxy2 m
+  → Effect Unit
+checkMonadShow _ = do
+
+  log "Checking 'Left identity' law for Monad"
+  quickCheck' 1000 leftIdentity
+
+  log "Checking 'Right identity' law for Monad"
+  quickCheck' 1000 rightIdentity
+
+  where
+
+  leftIdentity ∷ A → (A → m A) → Result
+  leftIdentity x f = (pure x >>= f) === f x
+
+  rightIdentity ∷ m A → Result
+  rightIdentity m = (m >>= pure) === m

--- a/src/Test/QuickCheck/Laws/Control/MonadPlus.purs
+++ b/src/Test/QuickCheck/Laws/Control/MonadPlus.purs
@@ -6,7 +6,7 @@ import Control.Alt ((<|>))
 import Control.MonadPlus (class MonadPlus)
 import Effect (Effect)
 import Effect.Console (log)
-import Test.QuickCheck (quickCheck')
+import Test.QuickCheck (quickCheck', Result, (===))
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 import Test.QuickCheck.Laws (A, B)
 import Type.Proxy (Proxy2)
@@ -29,3 +29,25 @@ checkMonadPlus _ = do
 
   distributivity ∷ m A → m A → (A → m B) → Boolean
   distributivity x y f = ((x <|> y) >>= f) == ((x >>= f) <|> (y >>= f))
+
+
+-- | Like `checkMonadPlus`, but with better error reporting.
+-- | - Distributivity: `(x <|> y) >>= f == (x >>= f) <|> (y >>= f)`
+checkMonadPlusShow
+  ∷ ∀ m
+  . MonadPlus m
+  ⇒ Arbitrary (m A)
+  ⇒ Arbitrary (m B)
+  ⇒ Eq (m B)
+  ⇒ Show (m B)
+  ⇒ Proxy2 m
+  → Effect Unit
+checkMonadPlusShow _ = do
+
+  log "Checking 'Distributivity' law for MonadPlus"
+  quickCheck' 1000 distributivity
+
+  where
+
+  distributivity ∷ m A → m A → (A → m B) → Result
+  distributivity x y f = ((x <|> y) >>= f) === ((x >>= f) <|> (y >>= f))

--- a/src/Test/QuickCheck/Laws/Control/MonadZero.purs
+++ b/src/Test/QuickCheck/Laws/Control/MonadZero.purs
@@ -6,7 +6,7 @@ import Control.MonadZero (class MonadZero)
 import Control.Plus (empty)
 import Effect (Effect)
 import Effect.Console (log)
-import Test.QuickCheck (quickCheck')
+import Test.QuickCheck (quickCheck', Result, (===))
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 import Test.QuickCheck.Laws (A, B)
 import Type.Proxy (Proxy2)
@@ -29,3 +29,25 @@ checkMonadZero _ = do
 
   annihilation ∷ (A → m B) → Boolean
   annihilation f = (empty >>= f) == empty
+
+
+-- | Like `checkMonadZero`, but with better error reporting.
+-- | - Annihilation: `empty >>= f = empty`
+checkMonadZeroShow
+  ∷ ∀ m
+  . MonadZero m
+  ⇒ Arbitrary (m A)
+  ⇒ Arbitrary (m B)
+  ⇒ Eq (m B)
+  ⇒ Show (m B)
+  ⇒ Proxy2 m
+  → Effect Unit
+checkMonadZeroShow _ = do
+
+  log "Checking 'Annihilation' law for MonadZero"
+  quickCheck' 1000 annihilation
+
+  where
+
+  annihilation ∷ (A → m B) → Result
+  annihilation f = (empty >>= f) === empty

--- a/src/Test/QuickCheck/Laws/Control/Plus.purs
+++ b/src/Test/QuickCheck/Laws/Control/Plus.purs
@@ -6,7 +6,7 @@ import Control.Alt ((<|>))
 import Control.Plus (class Plus, empty)
 import Effect (Effect)
 import Effect.Console (log)
-import Test.QuickCheck (quickCheck')
+import Test.QuickCheck (quickCheck', Result, (===))
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 import Test.QuickCheck.Laws (A, B)
 import Type.Proxy (Proxy2)
@@ -43,3 +43,39 @@ checkPlus _ = do
 
   annihilation ∷ (A → B) → Boolean
   annihilation f = (f <$> empty) == empty ∷ f B
+
+
+-- | - Left identity: `empty <|> x == x`
+-- | - Right identity: `x <|> empty == x`
+-- | - Annihilation: `f <$> empty == empty`
+checkPlusShow
+  ∷ ∀ f
+  . Plus f
+  ⇒ Arbitrary (f A)
+  ⇒ Eq (f A)
+  ⇒ Eq (f B)
+  ⇒ Show (f A)
+  ⇒ Show (f B)
+  ⇒ Proxy2 f
+  → Effect Unit
+checkPlusShow _ = do
+
+  log "Checking 'Left identity' law for Plus"
+  quickCheck' 1000 leftIdentity
+
+  log "Checking 'Right identity' law for Plus"
+  quickCheck' 1000 rightIdentity
+
+  log "Checking 'Annihilation' law for Plus"
+  quickCheck' 1000 annihilation
+
+  where
+
+  leftIdentity ∷ f A → Result
+  leftIdentity x = (empty <|> x) === x
+
+  rightIdentity ∷ f A → Result
+  rightIdentity x = (x <|> empty) === x
+
+  annihilation ∷ (A → B) → Result
+  annihilation f = (f <$> empty) === empty ∷ f B

--- a/src/Test/QuickCheck/Laws/Control/Semigroupoid.purs
+++ b/src/Test/QuickCheck/Laws/Control/Semigroupoid.purs
@@ -4,7 +4,7 @@ import Prelude
 
 import Effect (Effect)
 import Effect.Console (log)
-import Test.QuickCheck (quickCheck')
+import Test.QuickCheck (quickCheck', Result, (===))
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 import Test.QuickCheck.Laws (B, C, D, E)
 import Type.Proxy (Proxy3)
@@ -28,3 +28,26 @@ checkSemigroupoid _ = do
 
   associativity ∷ a D E → a C D → a B C → Boolean
   associativity p q r = (p <<< (q <<< r)) == ((p <<< q) <<< r)
+
+
+-- | Like `checkSemigroupoid`, but with better error reporting.
+-- | - Associativity: `p <<< (q <<< r) = (p <<< q) <<< r`
+checkSemigroupoidShow
+  ∷ ∀ a
+  . Semigroupoid a
+  ⇒ Arbitrary (a B C)
+  ⇒ Arbitrary (a C D)
+  ⇒ Arbitrary (a D E)
+  ⇒ Eq (a B E)
+  ⇒ Show (a B E)
+  ⇒ Proxy3 a
+  → Effect Unit
+checkSemigroupoidShow _ = do
+
+  log "Checking 'Associativity' law for Semigroupoid"
+  quickCheck' 1000 associativity
+
+  where
+
+  associativity ∷ a D E → a C D → a B C → Result
+  associativity p q r = (p <<< (q <<< r)) === ((p <<< q) <<< r)

--- a/src/Test/QuickCheck/Laws/Data.purs
+++ b/src/Test/QuickCheck/Laws/Data.purs
@@ -1,17 +1,17 @@
 module Test.QuickCheck.Laws.Data (module Exports) where
 
-import Test.QuickCheck.Laws.Data.BooleanAlgebra (checkBooleanAlgebra) as Exports
-import Test.QuickCheck.Laws.Data.Bounded (checkBounded) as Exports
-import Test.QuickCheck.Laws.Data.CommutativeRing (checkCommutativeRing) as Exports
-import Test.QuickCheck.Laws.Data.Eq (checkEq) as Exports
-import Test.QuickCheck.Laws.Data.BoundedEnum (checkBoundedEnum) as Exports
-import Test.QuickCheck.Laws.Data.EuclideanRing (checkEuclideanRing) as Exports
-import Test.QuickCheck.Laws.Data.DivisionRing (checkDivisionRing) as Exports
-import Test.QuickCheck.Laws.Data.Foldable (checkFoldable, checkFoldableFunctor) as Exports
-import Test.QuickCheck.Laws.Data.Functor (checkFunctor) as Exports
-import Test.QuickCheck.Laws.Data.HeytingAlgebra (checkHeytingAlgebra) as Exports
-import Test.QuickCheck.Laws.Data.Monoid (checkMonoid) as Exports
-import Test.QuickCheck.Laws.Data.Ord (checkOrd) as Exports
-import Test.QuickCheck.Laws.Data.Ring (checkRing) as Exports
-import Test.QuickCheck.Laws.Data.Semigroup (checkSemigroup) as Exports
-import Test.QuickCheck.Laws.Data.Semiring (checkSemiring) as Exports
+import Test.QuickCheck.Laws.Data.BooleanAlgebra (checkBooleanAlgebra, checkBooleanAlgebraShow) as Exports
+import Test.QuickCheck.Laws.Data.Bounded (checkBounded, checkBoundedShow) as Exports
+import Test.QuickCheck.Laws.Data.CommutativeRing (checkCommutativeRing, checkCommutativeRingShow) as Exports
+import Test.QuickCheck.Laws.Data.Eq (checkEq, checkEqShow) as Exports
+import Test.QuickCheck.Laws.Data.BoundedEnum (checkBoundedEnum, checkBoundedEnumShow) as Exports
+import Test.QuickCheck.Laws.Data.EuclideanRing (checkEuclideanRing, checkEuclideanRingShow) as Exports
+import Test.QuickCheck.Laws.Data.DivisionRing (checkDivisionRing, checkDivisionRingShow) as Exports
+import Test.QuickCheck.Laws.Data.Foldable (checkFoldable, checkFoldableFunctor, checkFoldableShow, checkFoldableFunctorShow) as Exports
+import Test.QuickCheck.Laws.Data.Functor (checkFunctor, checkFunctorShow) as Exports
+import Test.QuickCheck.Laws.Data.HeytingAlgebra (checkHeytingAlgebra, checkHeytingAlgebraShow) as Exports
+import Test.QuickCheck.Laws.Data.Monoid (checkMonoid, checkMonoidShow) as Exports
+import Test.QuickCheck.Laws.Data.Ord (checkOrd, checkOrdShow) as Exports
+import Test.QuickCheck.Laws.Data.Ring (checkRing, checkRingShow) as Exports
+import Test.QuickCheck.Laws.Data.Semigroup (checkSemigroup, checkSemigroupShow) as Exports
+import Test.QuickCheck.Laws.Data.Semiring (checkSemiring, checkSemiringShow) as Exports

--- a/src/Test/QuickCheck/Laws/Data/BooleanAlgebra.purs
+++ b/src/Test/QuickCheck/Laws/Data/BooleanAlgebra.purs
@@ -5,7 +5,7 @@ import Prelude
 import Data.BooleanAlgebra (tt)
 import Effect (Effect)
 import Effect.Console (log)
-import Test.QuickCheck (quickCheck')
+import Test.QuickCheck (quickCheck', Result, (===))
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 import Type.Proxy (Proxy)
 
@@ -26,3 +26,24 @@ checkBooleanAlgebra _ = do
 
   excludedMiddle ∷ a → Boolean
   excludedMiddle a = (a || not a) == tt
+
+
+
+-- | - Excluded middle: `a || not a = tt`, with better error reporting
+checkBooleanAlgebraShow
+  ∷ ∀ a
+  . Arbitrary a
+  ⇒ BooleanAlgebra a
+  ⇒ Eq a
+  ⇒ Show a
+  ⇒ Proxy a
+  → Effect Unit
+checkBooleanAlgebraShow _ = do
+
+  log "Checking 'Excluded middle' law for BooleanAlgebra"
+  quickCheck' 1000 excludedMiddle
+
+  where
+
+  excludedMiddle ∷ a → Result
+  excludedMiddle a = (a || not a) === tt

--- a/src/Test/QuickCheck/Laws/Data/BooleanAlgebra.purs
+++ b/src/Test/QuickCheck/Laws/Data/BooleanAlgebra.purs
@@ -28,8 +28,8 @@ checkBooleanAlgebra _ = do
   excludedMiddle a = (a || not a) == tt
 
 
-
--- | - Excluded middle: `a || not a = tt`, with better error reporting
+-- | Like `checkBooleanAlgebra`, but with better error reporting.
+-- | - Excluded middle: `a || not a = tt`
 checkBooleanAlgebraShow
   ∷ ∀ a
   . Arbitrary a

--- a/src/Test/QuickCheck/Laws/Data/Bounded.purs
+++ b/src/Test/QuickCheck/Laws/Data/Bounded.purs
@@ -28,7 +28,8 @@ checkBounded _ = do
   ordering a = bottom <= a && a <= top
 
 
--- | - Ordering: `bottom <= a <= top`, with better error reporting
+-- | Like `checkBounded`, but with better error reporting.
+-- | - Ordering: `bottom <= a <= top`
 checkBoundedShow
   ∷ ∀ a
   . Arbitrary a

--- a/src/Test/QuickCheck/Laws/Data/Bounded.purs
+++ b/src/Test/QuickCheck/Laws/Data/Bounded.purs
@@ -4,7 +4,8 @@ import Prelude
 
 import Effect (Effect)
 import Effect.Console (log)
-import Test.QuickCheck (quickCheck')
+import Test.QuickCheck (quickCheck', Result, (<=?))
+import Test.QuickCheck.Combinators ((&=&))
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 import Type.Proxy (Proxy)
 
@@ -25,3 +26,23 @@ checkBounded _ = do
 
   ordering ∷ a → Boolean
   ordering a = bottom <= a && a <= top
+
+
+-- | - Ordering: `bottom <= a <= top`, with better error reporting
+checkBoundedShow
+  ∷ ∀ a
+  . Arbitrary a
+  ⇒ Bounded a
+  ⇒ Ord a
+  ⇒ Show a
+  ⇒ Proxy a
+  → Effect Unit
+checkBoundedShow _ = do
+
+  log "Checking 'Ordering' law for Bounded"
+  quickCheck' 1000 ordering
+
+  where
+
+  ordering ∷ a → Result
+  ordering a = (bottom <=? a) &=& (a <=? top)

--- a/src/Test/QuickCheck/Laws/Data/BoundedEnum.purs
+++ b/src/Test/QuickCheck/Laws/Data/BoundedEnum.purs
@@ -89,7 +89,7 @@ checkBoundedEnum _ = do
     tofromenumLaw a = toEnum (fromEnum a) == Just a
 
 
--- | Same as `checkBoundedEnum`, with better error reporting.
+-- | Like `checkBoundedEnum`, but with better error reporting.
 -- | - succ: `succ bottom >>= succ >>= succ ... succ [cardinality - 1 times] = top`
 -- | - pred: `pred top    >>= pred >>= pred ... pred [cardinality - 1 times] = bottom`
 -- | - predsucc: `forall a > bottom: pred a >>= succ = Just a`

--- a/src/Test/QuickCheck/Laws/Data/CommutativeRing.purs
+++ b/src/Test/QuickCheck/Laws/Data/CommutativeRing.purs
@@ -4,7 +4,7 @@ import Prelude
 
 import Effect (Effect)
 import Effect.Console (log)
-import Test.QuickCheck (quickCheck')
+import Test.QuickCheck (quickCheck', Result, (===))
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 import Type.Proxy (Proxy)
 
@@ -25,3 +25,24 @@ checkCommutativeRing _ = do
 
   commutativeMultiplication ∷ a → a → Boolean
   commutativeMultiplication a b = a * b == b * a
+
+
+-- | Same as `checkCommutativeRing`, but with better error reporting.
+-- | - Commutative multiplication: `a * b = b * a`
+checkCommutativeRingShow
+  ∷ ∀ a
+  . CommutativeRing a
+  ⇒ Arbitrary a
+  ⇒ Eq a
+  ⇒ Show a
+  ⇒ Proxy a
+  → Effect Unit
+checkCommutativeRingShow _ = do
+
+  log "Checking 'Commutative multiplication' law for CommutativeRing"
+  quickCheck' 1000 commutativeMultiplication
+
+  where
+
+  commutativeMultiplication ∷ a → a → Result
+  commutativeMultiplication a b = a * b === b * a

--- a/src/Test/QuickCheck/Laws/Data/CommutativeRing.purs
+++ b/src/Test/QuickCheck/Laws/Data/CommutativeRing.purs
@@ -27,7 +27,7 @@ checkCommutativeRing _ = do
   commutativeMultiplication a b = a * b == b * a
 
 
--- | Same as `checkCommutativeRing`, but with better error reporting.
+-- | Like `checkCommutativeRing`, but with better error reporting.
 -- | - Commutative multiplication: `a * b = b * a`
 checkCommutativeRingShow
   ∷ ∀ a

--- a/src/Test/QuickCheck/Laws/Data/DivisionRing.purs
+++ b/src/Test/QuickCheck/Laws/Data/DivisionRing.purs
@@ -4,7 +4,8 @@ import Prelude
 
 import Effect (Effect)
 import Effect.Console (log)
-import Test.QuickCheck (quickCheck')
+import Test.QuickCheck (quickCheck', Result, (===), (/==))
+import Test.QuickCheck.Combinators ((|=|), (&=&))
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 import Type.Proxy (Proxy)
 
@@ -35,3 +36,36 @@ checkDivisionRing _ = do
     | a == zero = true
     | (recip a * a == a * recip a) && (recip a * a == one) && (a * recip a == one) = true
     | otherwise = false
+
+
+-- | Same as `checkDivisionRing`, but with better error reporting.
+-- | Non-zero ring: one /= zero
+-- | Non-zero multiplicative inverse: recip a * a = a * recip a = one for all non-zero a
+checkDivisionRingShow
+  ∷ ∀ a
+  . DivisionRing a
+  ⇒ Arbitrary a
+  ⇒ Eq a
+  ⇒ Show a
+  ⇒ Proxy a
+  → Effect Unit
+checkDivisionRingShow _ = do
+
+  log "Checking 'Non-zero ring' law for DivisionRing"
+  quickCheck' 1000 nonZero
+
+  log "Checking 'Non-zero multiplicative inverse' law for DivisionRing"
+  quickCheck' 1000 inverse
+
+  where
+
+  nonZero ∷ Result
+  nonZero = (one :: Eq a => a) /== zero
+
+  inverse ∷ DivisionRing a => a → Result
+  inverse a =
+    let isZero = a === zero
+        commRecip = recip a * a === a * recip a
+        recipOneR = recip a * a === one
+        recipOneL = a * recip a === one
+    in  isZero |=| (commRecip &=& recipOneR &=& recipOneL)

--- a/src/Test/QuickCheck/Laws/Data/DivisionRing.purs
+++ b/src/Test/QuickCheck/Laws/Data/DivisionRing.purs
@@ -38,7 +38,7 @@ checkDivisionRing _ = do
     | otherwise = false
 
 
--- | Same as `checkDivisionRing`, but with better error reporting.
+-- | Like `checkDivisionRing`, but with better error reporting.
 -- | Non-zero ring: one /= zero
 -- | Non-zero multiplicative inverse: recip a * a = a * recip a = one for all non-zero a
 checkDivisionRingShow

--- a/src/Test/QuickCheck/Laws/Data/Eq.purs
+++ b/src/Test/QuickCheck/Laws/Data/Eq.purs
@@ -83,7 +83,7 @@ checkEqShow _ = do
   symmetry x y = ((x === y) ==> (y === x)) &=& ((x /== y) ==> (y /== x))
 
   transitivity ∷ a → a → a → Result
-  transitivity x y z = ((x === y) &=& (y === x)) ==> (x === z)
+  transitivity x y z = ((x === y) &=& (y === z)) ==> (x === z)
 
   negation ∷ a → a → Result
   negation x y = (x /== y) ==> not' "Shouldn't be equal" (x === y)

--- a/src/Test/QuickCheck/Laws/Data/Eq.purs
+++ b/src/Test/QuickCheck/Laws/Data/Eq.purs
@@ -48,7 +48,7 @@ checkEq _ = do
   negation x y = (x /= y) == not (x == y)
 
 
--- | Like `checkEq`, with better error reporting.
+-- | Like `checkEq`, but with better error reporting.
 -- | - Reflexivity: `x == x = true`
 -- | - Symmetry: `x == y = y == x`
 -- | - Transitivity: if `x == y` and `y == z` then `x == z`

--- a/src/Test/QuickCheck/Laws/Data/Eq.purs
+++ b/src/Test/QuickCheck/Laws/Data/Eq.purs
@@ -4,7 +4,8 @@ import Prelude
 
 import Effect (Effect)
 import Effect.Console (log)
-import Test.QuickCheck (quickCheck')
+import Test.QuickCheck (quickCheck', Result, (===), (/==))
+import Test.QuickCheck.Combinators ((==>), (&=&), not')
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 import Type.Proxy (Proxy)
 
@@ -45,3 +46,44 @@ checkEq _ = do
 
   negation ∷ a → a → Boolean
   negation x y = (x /= y) == not (x == y)
+
+
+-- | Like `checkEq`, with better error reporting.
+-- | - Reflexivity: `x == x = true`
+-- | - Symmetry: `x == y = y == x`
+-- | - Transitivity: if `x == y` and `y == z` then `x == z`
+-- | - Negation: `x /= y = not (x == y)`
+checkEqShow
+  ∷ ∀ a
+  . Arbitrary a
+  ⇒ Eq a
+  ⇒ Show a
+  ⇒ Proxy a
+  → Effect Unit
+checkEqShow _ = do
+
+  log "Checking 'Reflexivity' law for Eq"
+  quickCheck' 1000 reflexivity
+
+  log "Checking 'Symmetry' law for Eq"
+  quickCheck' 1000 symmetry
+
+  log "Checking 'Transitivity' law for Eq"
+  quickCheck' 1000 transitivity
+
+  log "Checking 'Negation' law for Eq"
+  quickCheck' 1000 negation
+
+  where
+
+  reflexivity ∷ a → Result
+  reflexivity x = x === x
+
+  symmetry ∷ a → a → Result
+  symmetry x y = ((x === y) ==> (y === x)) &=& ((x /== y) ==> (y /== x))
+
+  transitivity ∷ a → a → a → Result
+  transitivity x y z = ((x === y) &=& (y === x)) ==> (x === z)
+
+  negation ∷ a → a → Result
+  negation x y = (x /== y) ==> not' "Shouldn't be equal" (x === y)

--- a/src/Test/QuickCheck/Laws/Data/EuclideanRing.purs
+++ b/src/Test/QuickCheck/Laws/Data/EuclideanRing.purs
@@ -4,7 +4,8 @@ import Prelude
 
 import Effect (Effect)
 import Effect.Console (log)
-import Test.QuickCheck (quickCheck')
+import Test.QuickCheck (quickCheck', Result, (===), (/==), (>=?), (<?), (<=?))
+import Test.QuickCheck.Combinators ((|=|), (&=&), (==>))
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 import Type.Proxy (Proxy)
 
@@ -68,3 +69,60 @@ checkEuclideanRing _ = do
   submultiplicative a b
     | a /= zero && b /= zero = degree a <= degree (a * b)
     | otherwise = true
+
+
+-- | Like `checkEuclideanRing`, but with better error reporting.
+-- | - Integral domain: `one /= zero`, and if `a` and `b` are both nonzero then
+-- |   so is their product `a * b`
+-- | - Euclidean function `degree`:
+-- |   - Nonnegativity: For all nonzero `a`, `degree a >= 0`
+-- |   - Quotient/remainder: For all `a` and `b`, where `b` is nonzero,
+-- |     let `q = a / b` and ``r = a `mod` b``; then `a = q*b + r`, and also
+-- |     either `r = zero` or `degree r < degree b`
+-- | - Submultiplicative euclidean function:
+-- |   - For all nonzero `a` and `b`, `degree a <= degree (a * b)`
+checkEuclideanRingShow
+  ∷ ∀ a
+  . EuclideanRing a
+  ⇒ Arbitrary a
+  ⇒ Eq a
+  ⇒ Show a
+  ⇒ Proxy a
+  → Effect Unit
+checkEuclideanRingShow _ = do
+
+  log "Checking 'Integral domain' law for EuclideanRing"
+  log "one /= zero:"
+  quickCheck' 1 \(_ :: Unit) -> (zero /= one :: a)
+  log "product of nonzero elements is nonzero:"
+  quickCheck' 1000 integralDomain
+
+  log "Checking 'Nonnegative euclidean function' law for EuclideanRing"
+  quickCheck' 1000 nonnegativeEuclideanFunc
+
+  log "Checking 'Quotient/remainder' law for EuclideanRing"
+  quickCheck' 1000 quotRem
+
+  log "Checking 'Submultiplicative euclidean function' law for EuclideanRing"
+  quickCheck' 1000 submultiplicative
+
+  where
+
+  integralDomain ∷ a → a → Result
+  integralDomain a b =
+    (a /== zero) &=& (b /== zero) ==> (a * b /== zero)
+
+  nonnegativeEuclideanFunc ∷ a → Result
+  nonnegativeEuclideanFunc a =
+    (a /== zero) ==> (degree a >=? zero)
+
+  quotRem ∷ a → a → Result
+  quotRem a b =
+    (b /== zero) ==>
+      let q = a / b
+          r = a `mod` b
+      in (a === q*b + r) &=& ((r === zero) |=| (degree r <? degree b))
+
+  submultiplicative ∷ a → a → Result
+  submultiplicative a b =
+    ((a /== zero) &=& (b /== zero)) ==> (degree a <=? degree (a * b))

--- a/src/Test/QuickCheck/Laws/Data/Field.purs
+++ b/src/Test/QuickCheck/Laws/Data/Field.purs
@@ -4,7 +4,7 @@ import Prelude
 
 import Effect (Effect)
 import Effect.Console (log)
-import Test.QuickCheck (quickCheck')
+import Test.QuickCheck (quickCheck', Result, (===))
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 import Type.Proxy (Proxy)
 
@@ -25,3 +25,24 @@ checkField _ = do
 
   multiplicativeInverse ∷ a → a → Boolean
   multiplicativeInverse x y = x `mod` y == zero
+
+
+-- | Like `checkField`, but with better error reporting.
+-- | - Non-zero multiplicative inverse: ``a `mod` b = 0` for all `a` and `b`
+checkFieldShow
+  ∷ ∀ a
+  . Field a
+  ⇒ Arbitrary a
+  ⇒ Eq a
+  ⇒ Show a
+  ⇒ Proxy a
+  → Effect Unit
+checkFieldShow _ = do
+
+  log "Checking 'Non-zero multiplicative inverse' law for Field"
+  quickCheck' 1000 multiplicativeInverse
+
+  where
+
+  multiplicativeInverse ∷ a → a → Result
+  multiplicativeInverse x y = x `mod` y === zero

--- a/src/Test/QuickCheck/Laws/Data/Functor.purs
+++ b/src/Test/QuickCheck/Laws/Data/Functor.purs
@@ -5,7 +5,7 @@ import Prelude
 import Data.Function as F
 import Effect (Effect)
 import Effect.Console (log)
-import Test.QuickCheck (quickCheck')
+import Test.QuickCheck (quickCheck', Result, (===))
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 import Test.QuickCheck.Laws (A, B)
 import Type.Proxy (Proxy2)
@@ -34,3 +34,31 @@ checkFunctor _ = do
 
   composition ∷ (B → A) → (A → B) → f A → Boolean
   composition f g x = ((<$>) (f <<< g) x) == (((f <$> _) <<< (g <$> _)) x)
+
+
+-- | Like `checkFunctor`, but with better error reporting.
+-- | - Identity: `(<$>) id = id`
+-- | - Composition: `(<$>) (f <<< g) = (f <$>) <<< (g <$>)`
+checkFunctorShow
+  ∷ ∀ f
+  . Functor f
+  ⇒ Arbitrary (f A)
+  ⇒ Eq (f A)
+  ⇒ Show (f A)
+  ⇒ Proxy2 f
+  → Effect Unit
+checkFunctorShow _ = do
+
+  log "Checking 'Identity' law for Functor"
+  quickCheck' 1000 identity
+
+  log "Checking 'Composition' law for Functor"
+  quickCheck' 1000 composition
+
+  where
+
+  identity ∷ f A → Result
+  identity f = (F.identity <$> f) === F.identity f
+
+  composition ∷ (B → A) → (A → B) → f A → Result
+  composition f g x = ((<$>) (f <<< g) x) === (((f <$> _) <<< (g <$> _)) x)

--- a/src/Test/QuickCheck/Laws/Data/HeytingAlgebra.purs
+++ b/src/Test/QuickCheck/Laws/Data/HeytingAlgebra.purs
@@ -5,7 +5,8 @@ import Prelude
 import Data.HeytingAlgebra (tt, ff, implies)
 import Effect (Effect)
 import Effect.Console (log)
-import Test.QuickCheck (quickCheck')
+import Test.QuickCheck (quickCheck', Result, (===))
+import Test.QuickCheck.Combinators ((&=&))
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 import Type.Proxy (Proxy)
 
@@ -108,3 +109,106 @@ checkHeytingAlgebra _ = do
 
   complemented ∷ a → Boolean
   complemented a = not a == (a `implies` ff)
+
+
+-- | Like `checkHeytingAlgebra`, but with better error reporting.
+-- | - Associativity:
+-- |   - `a || (b || c) = (a || b) || c`
+-- |   - `a && (b && c) = (a && b) && c`
+-- | - Commutativity:
+-- |   - `a || b = b || a`
+-- |   - `a && b = b && a`
+-- | - Absorption:
+-- |   - `a || (a && b) = a`
+-- |   - `a && (a || b) = a`
+-- | - Idempotent:
+-- |   - `a || a = a`
+-- |   - `a && a = a`
+-- | - Identity:
+-- |   - `a || ff = a`
+-- |   - `a && tt = a`
+-- | - Implication:
+-- |   - ``a `implies` a = tt``
+-- |   - ``a && (a `implies` b) = a && b``
+-- |   - ``b && (a `implies` b) = b``
+-- |   - ``a `implies` (b && c) = (a `implies` b) && (a `implies` c)``
+-- | - Complemented:
+-- |   - ``not a = a `implies` ff``
+checkHeytingAlgebraShow
+  ∷ ∀ a
+  . Arbitrary a
+  ⇒ HeytingAlgebra a
+  ⇒ Eq a
+  ⇒ Show a
+  ⇒ Proxy a
+  → Effect Unit
+checkHeytingAlgebraShow _ = do
+
+  log "Checking 'Associativity of disjunction' law for HeytingAlgebra"
+  quickCheck' 1000 (associativity (||))
+
+  log "Checking 'Associativity of conjunction' law for HeytingAlgebra"
+  quickCheck' 1000 (associativity (&&))
+
+  log "Checking 'Commutativity of disjunction' law for HeytingAlgebra"
+  quickCheck' 1000 (commutativity (||))
+
+  log "Checking 'Commutativity of conjunction' law for HeytingAlgebra"
+  quickCheck' 1000 (commutativity (&&))
+
+  log "Checking 'Absorption of disjunction' law for HeytingAlgebra"
+  quickCheck' 1000 (absorption (||) (&&))
+
+  log "Checking 'Absorption of conjunction' law for HeytingAlgebra"
+  quickCheck' 1000 (absorption (&&) (||))
+
+  log "Checking 'Idempotent disjunction' law for HeytingAlgebra"
+  quickCheck' 1000 (idempotent (||))
+
+  log "Checking 'Idempotent conjunction' law for HeytingAlgebra"
+  quickCheck' 1000 (idempotent (&&))
+
+  log "Checking 'Disjunction identity' law for HeytingAlgebra"
+  quickCheck' 1000 (identity (||) ff)
+
+  log "Checking 'Conjunction identity' law for HeytingAlgebra"
+  quickCheck' 1000 (identity (&&) tt)
+
+  log "Checking 'Implication' laws for HeytingAlgebra"
+  quickCheck' 1000 implicationId
+  quickCheck' 1000 implications
+  quickCheck' 1000 distributiveImplication
+
+  log "Checking 'Complemented' law for HeytingAlgebra"
+  quickCheck' 1000 complemented
+
+  where
+
+  associativity ∷ (a → a → a) → a → a → a → Result
+  associativity op a b c = (a `op` (b `op` c)) === ((a `op` b) `op` c)
+
+  commutativity ∷ (a → a → a) → a → a → Result
+  commutativity op a b = (a `op` b) === (b `op` a)
+
+  absorption ∷ (a → a → a) → (a → a → a) → a → a → Result
+  absorption op1 op2 a b = (a `op1` (a `op2` b)) === a
+
+  idempotent ∷ (a → a → a) → a → a → Result
+  idempotent op a b = a `op` a === a
+
+  identity ∷ (a → a → a) → a → a → Result
+  identity op ident a = a `op` ident === a
+
+  implicationId ∷ a → Result
+  implicationId a = (a `implies` a) === tt
+
+  implications ∷ a → a → Result
+  implications a b
+    = ((a && (a `implies` b)) === (a && b))
+    &=& ((b && (a `implies` b)) === b)
+
+  distributiveImplication ∷ a → a → a → Result
+  distributiveImplication a b c = (a `implies` (b && c)) === ((a `implies` b) && (a `implies` c))
+
+  complemented ∷ a → Result
+  complemented a = not a === (a `implies` ff)

--- a/src/Test/QuickCheck/Laws/Data/Monoid.purs
+++ b/src/Test/QuickCheck/Laws/Data/Monoid.purs
@@ -4,7 +4,7 @@ import Prelude
 
 import Effect (Effect)
 import Effect.Console (log)
-import Test.QuickCheck (quickCheck')
+import Test.QuickCheck (quickCheck', Result, (===))
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 import Type.Proxy (Proxy)
 
@@ -32,3 +32,31 @@ checkMonoid _ = do
 
   rightIdentity ∷ m → Boolean
   rightIdentity x = x <> mempty == x
+
+
+-- | Like `checkMonoid`, but with better error reporting.
+-- | - Left identity: `mempty <> x = x`
+-- | - Right identity: `x <> mempty = x`
+checkMonoidShow
+  ∷ ∀ m
+  . Monoid m
+  ⇒ Arbitrary m
+  ⇒ Eq m
+  ⇒ Show m
+  ⇒ Proxy m
+  → Effect Unit
+checkMonoidShow _ = do
+
+  log "Checking 'Left identity' law for Monoid"
+  quickCheck' 1000 leftIdentity
+
+  log "Checking 'Right identity' law for Monoid"
+  quickCheck' 1000 rightIdentity
+
+  where
+
+  leftIdentity ∷ m → Result
+  leftIdentity x = mempty <> x === x
+
+  rightIdentity ∷ m → Result
+  rightIdentity x = x <> mempty === x

--- a/src/Test/QuickCheck/Laws/Data/Ord.purs
+++ b/src/Test/QuickCheck/Laws/Data/Ord.purs
@@ -4,7 +4,8 @@ import Prelude
 
 import Effect (Effect)
 import Effect.Console (log)
-import Test.QuickCheck (quickCheck')
+import Test.QuickCheck (quickCheck', Result, (===), (<=?))
+import Test.QuickCheck.Combinators ((==>), (&=&))
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 import Type.Proxy (Proxy)
 
@@ -38,3 +39,37 @@ checkOrd _ = do
 
   transitivity ∷ a → a → a → Boolean
   transitivity a b c = if (a <= b) && (b <= c) then a <= c else true
+
+
+-- | Like `checkOrd`, but with better error reporting.
+-- | - Reflexivity: `a <= a`
+-- | - Antisymmetry: if `a <= b` and `b <= a` then `a = b`
+-- | - Transitivity: if `a <= b` and `b <= c` then `a <= c`
+checkOrdShow
+  ∷ ∀ a
+  . Arbitrary a
+  ⇒ Ord a
+  ⇒ Show a
+  ⇒ Proxy a
+  → Effect Unit
+checkOrdShow _ = do
+
+  log "Checking 'Reflexivity' law for Ord"
+  quickCheck' 1000 reflexivity
+
+  log "Checking 'Antisymmetry' law for Ord"
+  quickCheck' 1000 antisymmetry
+
+  log "Checking 'Transitivity' law for Ord"
+  quickCheck' 1000 transitivity
+
+  where
+
+  reflexivity ∷ a → Result
+  reflexivity a = a <=? a
+
+  antisymmetry ∷ a → a → Result
+  antisymmetry a b = ((a <=? b) &=& (b <=? a)) ==> (a === b)
+
+  transitivity ∷ a → a → a → Result
+  transitivity a b c = ((a <=? b) &=& (b <=? c)) ==> (a <=? c)

--- a/src/Test/QuickCheck/Laws/Data/Ring.purs
+++ b/src/Test/QuickCheck/Laws/Data/Ring.purs
@@ -4,7 +4,8 @@ import Prelude
 
 import Effect (Effect)
 import Effect.Console (log)
-import Test.QuickCheck (quickCheck')
+import Test.QuickCheck (quickCheck', Result, (===))
+import Test.QuickCheck.Combinators ((&=&))
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 import Type.Proxy (Proxy)
 
@@ -25,3 +26,24 @@ checkRing _ = do
 
   additiveInverse ∷ a → Boolean
   additiveInverse a = a - a == zero && a + (-a) == zero && (-a) + a == zero
+
+
+-- | Like `checkRing`, but with better error reporting.
+-- | - Additive inverse: `a - a = a + (-a) = (-a) + a = zero`
+checkRingShow
+  ∷ ∀ a
+  . Ring a
+  ⇒ Arbitrary a
+  ⇒ Eq a
+  ⇒ Show a
+  ⇒ Proxy a
+  → Effect Unit
+checkRingShow _ = do
+
+  log "Checking 'Additive inverse' law for Ring"
+  quickCheck' 1000 additiveInverse
+
+  where
+
+  additiveInverse ∷ a → Result
+  additiveInverse a = (a - a === zero) &=& (a + (-a) === zero) &=& ((-a) + a === zero)

--- a/src/Test/QuickCheck/Laws/Data/Semigroup.purs
+++ b/src/Test/QuickCheck/Laws/Data/Semigroup.purs
@@ -4,7 +4,7 @@ import Prelude
 
 import Effect (Effect)
 import Effect.Console (log)
-import Test.QuickCheck (quickCheck')
+import Test.QuickCheck (quickCheck', Result, (===))
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 import Type.Proxy (Proxy)
 
@@ -25,3 +25,24 @@ checkSemigroup _ = do
 
   associativity ∷ s → s → s → Boolean
   associativity x y z = ((x <> y) <> z) == (x <> (y <> z))
+
+
+-- | Like `checkSemigroup`, but with better error reporting.
+-- | - Associativity: `(x <> y) <> z = x <> (y <> z)`
+checkSemigroupShow
+  ∷ ∀ s
+  . Semigroup s
+  ⇒ Arbitrary s
+  ⇒ Eq s
+  ⇒ Show s
+  ⇒ Proxy s
+  → Effect Unit
+checkSemigroupShow _ = do
+
+  log "Checking 'Associativity' law for Semigroup"
+  quickCheck' 1000 associativity
+
+  where
+
+  associativity ∷ s → s → s → Result
+  associativity x y z = ((x <> y) <> z) === (x <> (y <> z))

--- a/src/Test/QuickCheck/Laws/Data/Semiring.purs
+++ b/src/Test/QuickCheck/Laws/Data/Semiring.purs
@@ -4,7 +4,8 @@ import Prelude
 
 import Effect (Effect)
 import Effect.Console (log)
-import Test.QuickCheck (quickCheck')
+import Test.QuickCheck (quickCheck', Result, (===))
+import Test.QuickCheck.Combinators ((&=&))
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 import Type.Proxy (Proxy)
 
@@ -74,3 +75,73 @@ checkSemiring _ = do
 
   annihiliation ∷ a → Boolean
   annihiliation a = (a * zero == zero) && (zero * a == zero)
+
+
+-- | Like `checkSemiring`, but with better error reporting
+-- | - Commutative monoid under addition:
+-- |   - Associativity: `(a + b) + c = a + (b + c)`
+-- |   - Identity: `zero + a = a + zero = a`
+-- |   - Commutative: `a + b = b + a`
+-- | - Monoid under multiplication:
+-- |   - Associativity: `(a * b) * c = a * (b * c)`
+-- |   - Identity: `one * a = a * one = a`
+-- | - Multiplication distributes over addition:
+-- |   - Left distributivity: `a * (b + c) = (a * b) + (a * c)`
+-- |   - Right distributivity: `(a + b) * c = (a * c) + (b * c)`
+-- | - Annihiliation: `zero * a = a * zero = zero`
+checkSemiringShow
+  ∷ ∀ a
+  . Semiring a
+  ⇒ Arbitrary a
+  ⇒ Eq a
+  ⇒ Show a
+  ⇒ Proxy a
+  → Effect Unit
+checkSemiringShow _ = do
+
+  log "Checking 'Associativity' law for Semiring addition"
+  quickCheck' 1000 associativeAddition
+
+  log "Checking 'Identity' law for Semiring addition"
+  quickCheck' 1000 identityAddition
+
+  log "Checking 'Commutative' law for Semiring addition"
+  quickCheck' 1000 commutativeAddition
+
+  log "Checking 'Associativity' law for Semiring multiplication"
+  quickCheck' 1000 associativeMultiplication
+
+  log "Checking 'Identity' law for Semiring multiplication"
+  quickCheck' 1000 identityMultiplication
+
+  log "Checking 'Left distribution' law for Semiring"
+  quickCheck' 1000 leftDistribution
+
+  log "Checking 'Right distribution' law for Semiring"
+  quickCheck' 1000 rightDistribution
+
+  where
+
+  associativeAddition ∷ a → a → a → Result
+  associativeAddition a b c = (a + b) + c === a + (b + c)
+
+  identityAddition ∷ a → Result
+  identityAddition a = (zero + a === a) &=& (a + zero === a)
+
+  commutativeAddition ∷ a → a → Result
+  commutativeAddition a b = a + b === b + a
+
+  associativeMultiplication ∷ a → a → a → Result
+  associativeMultiplication a b c = (a * b) * c === a * (b * c)
+
+  identityMultiplication ∷ a → Result
+  identityMultiplication a = (one * a === a) &=& (a * one === a)
+
+  leftDistribution ∷ a → a → a → Result
+  leftDistribution a b c = a * (b + c) === (a * b) + (a * c)
+
+  rightDistribution ∷ a → a → a → Result
+  rightDistribution a b c = (a + b) * c === (a * c) + (b * c)
+
+  annihiliation ∷ a → Result
+  annihiliation a = (a * zero === zero) &=& (zero * a === zero)

--- a/test/Test/Data/Either.purs
+++ b/test/Test/Data/Either.purs
@@ -16,6 +16,11 @@ checkEither = checkLaws "Either" do
   Data.checkBounded prxEither
   Data.checkFunctor prx2Either
   Data.checkFoldableFunctor prx2Either
+  Data.checkEqShow prxEither
+  Data.checkOrdShow prxEither
+  Data.checkBoundedShow prxEither
+  Data.checkFunctorShow prx2Either
+  Data.checkFoldableFunctorShow prx2Either
   Control.checkApply prx2Either
   Control.checkApplicative prx2Either
   Control.checkAlt prx2Either

--- a/test/Test/Data/Either.purs
+++ b/test/Test/Data/Either.purs
@@ -16,17 +16,23 @@ checkEither = checkLaws "Either" do
   Data.checkBounded prxEither
   Data.checkFunctor prx2Either
   Data.checkFoldableFunctor prx2Either
-  Data.checkEqShow prxEither
-  Data.checkOrdShow prxEither
-  Data.checkBoundedShow prxEither
-  Data.checkFunctorShow prx2Either
-  Data.checkFoldableFunctorShow prx2Either
   Control.checkApply prx2Either
   Control.checkApplicative prx2Either
   Control.checkAlt prx2Either
   Control.checkBind prx2Either
   Control.checkMonad prx2Either
   Control.checkExtend prx2Either
+  Data.checkEqShow prxEither
+  Data.checkOrdShow prxEither
+  Data.checkBoundedShow prxEither
+  Data.checkFunctorShow prx2Either
+  Data.checkFoldableFunctorShow prx2Either
+  Control.checkApplyShow prx2Either
+  Control.checkApplicativeShow prx2Either
+  Control.checkAltShow prx2Either
+  Control.checkBindShow prx2Either
+  Control.checkMonadShow prx2Either
+  Control.checkExtendShow prx2Either
   where
   prxEither = Proxy ∷ Proxy (Either A B)
   prx2Either = Proxy2 ∷ Proxy2 (Either C)

--- a/test/Test/Data/Identity.purs
+++ b/test/Test/Data/Identity.purs
@@ -14,9 +14,14 @@ checkIdentity = checkLaws "Identity" do
   Data.checkEq prxIdentity
   Data.checkOrd prxIdentity
   Data.checkBounded prxIdentity
+  Data.checkEqShow prxIdentity
+  Data.checkOrdShow prxIdentity
+  Data.checkBoundedShow prxIdentity
 
   Data.checkSemigroup prxIdentity
   Data.checkMonoid prxIdentity
+  Data.checkSemigroupShow prxIdentity
+  Data.checkMonoidShow prxIdentity
 
   -- Data.checkSemiring prxIdentity
   -- Data.checkEuclideanRing prxIdentity
@@ -26,6 +31,8 @@ checkIdentity = checkLaws "Identity" do
 
   Data.checkFunctor prx2Identity
   Data.checkFoldableFunctor prx2Identity
+  Data.checkFunctorShow prx2Identity
+  Data.checkFoldableFunctorShow prx2Identity
   Control.checkApply prx2Identity
   Control.checkApplicative prx2Identity
   Control.checkBind prx2Identity

--- a/test/Test/Data/Identity.purs
+++ b/test/Test/Data/Identity.purs
@@ -14,14 +14,9 @@ checkIdentity = checkLaws "Identity" do
   Data.checkEq prxIdentity
   Data.checkOrd prxIdentity
   Data.checkBounded prxIdentity
-  Data.checkEqShow prxIdentity
-  Data.checkOrdShow prxIdentity
-  Data.checkBoundedShow prxIdentity
 
   Data.checkSemigroup prxIdentity
   Data.checkMonoid prxIdentity
-  Data.checkSemigroupShow prxIdentity
-  Data.checkMonoidShow prxIdentity
 
   -- Data.checkSemiring prxIdentity
   -- Data.checkEuclideanRing prxIdentity
@@ -31,8 +26,6 @@ checkIdentity = checkLaws "Identity" do
 
   Data.checkFunctor prx2Identity
   Data.checkFoldableFunctor prx2Identity
-  Data.checkFunctorShow prx2Identity
-  Data.checkFoldableFunctorShow prx2Identity
   Control.checkApply prx2Identity
   Control.checkApplicative prx2Identity
   Control.checkBind prx2Identity
@@ -45,6 +38,33 @@ checkIdentity = checkLaws "Identity" do
   -- checkPlus prx2Identity
   -- checkAlternative prx2Identity
   -- checkMonadZero prx2Identity
+  Data.checkEqShow prxIdentity
+  Data.checkOrdShow prxIdentity
+  Data.checkBoundedShow prxIdentity
+
+  Data.checkSemigroupShow prxIdentity
+  Data.checkMonoidShow prxIdentity
+
+  -- Data.checkSemiringShow prxIdentity
+  -- Data.checkEuclideanRingShow prxIdentity
+  -- Data.checkRingShow prxIdentity
+  -- Data.checkCommutativeRingShow prxIdentity
+  -- Data.checkFieldShow prxIdentity
+
+  Data.checkFunctorShow prx2Identity
+  Data.checkFoldableFunctorShow prx2Identity
+  Control.checkApplyShow prx2Identity
+  Control.checkApplicativeShow prx2Identity
+  Control.checkBindShow prx2Identity
+  Control.checkMonadShow prx2Identity
+
+  Control.checkExtendShow prx2Identity
+  Control.checkComonadShow prx2Identity
+
+  -- checkAltShow prx2Identity
+  -- checkPlusShow prx2Identity
+  -- checkAlternativeShow prx2Identity
+  -- checkMonadZeroShow prx2Identity
   where
   prxIdentity = Proxy ∷ Proxy (Identity A)
   prx2Identity = Proxy2 ∷ Proxy2 Identity

--- a/test/Test/Data/List.purs
+++ b/test/Test/Data/List.purs
@@ -15,23 +15,32 @@ checkList = checkLaws "List" do
   Data.checkOrd prxList
   Data.checkFunctor prx2List
   Data.checkFoldableFunctor prx2List
-  Data.checkEqShow prxList
-  Data.checkOrdShow prxList
-  Data.checkFunctorShow prx2List
-  Data.checkFoldableFunctorShow prx2List
   Control.checkApply prx2List
   Control.checkApplicative prx2List
   Control.checkBind prx2List
   Control.checkMonad prx2List
   Data.checkSemigroup prxList
   Data.checkMonoid prxList
-  Data.checkSemigroupShow prxList
-  Data.checkMonoidShow prxList
   Control.checkAlt prx2List
   Control.checkPlus prx2List
   Control.checkAlternative prx2List
   Control.checkMonadZero prx2List
   Control.checkMonadPlus prx2List
+  Data.checkEqShow prxList
+  Data.checkOrdShow prxList
+  Data.checkFunctorShow prx2List
+  Data.checkFoldableFunctorShow prx2List
+  Control.checkApplyShow prx2List
+  Control.checkApplicativeShow prx2List
+  Control.checkBindShow prx2List
+  Control.checkMonadShow prx2List
+  Data.checkSemigroupShow prxList
+  Data.checkMonoidShow prxList
+  Control.checkAltShow prx2List
+  Control.checkPlusShow prx2List
+  Control.checkAlternativeShow prx2List
+  Control.checkMonadZeroShow prx2List
+  Control.checkMonadPlusShow prx2List
   where
   prxList = Proxy ∷ Proxy (List A)
   prx2List = Proxy2 ∷ Proxy2 List

--- a/test/Test/Data/List.purs
+++ b/test/Test/Data/List.purs
@@ -15,12 +15,18 @@ checkList = checkLaws "List" do
   Data.checkOrd prxList
   Data.checkFunctor prx2List
   Data.checkFoldableFunctor prx2List
+  Data.checkEqShow prxList
+  Data.checkOrdShow prxList
+  Data.checkFunctorShow prx2List
+  Data.checkFoldableFunctorShow prx2List
   Control.checkApply prx2List
   Control.checkApplicative prx2List
   Control.checkBind prx2List
   Control.checkMonad prx2List
   Data.checkSemigroup prxList
   Data.checkMonoid prxList
+  Data.checkSemigroupShow prxList
+  Data.checkMonoidShow prxList
   Control.checkAlt prx2List
   Control.checkPlus prx2List
   Control.checkAlternative prx2List

--- a/test/Test/Data/Maybe.purs
+++ b/test/Test/Data/Maybe.purs
@@ -18,13 +18,6 @@ checkMaybe = checkLaws "Maybe" do
   Data.checkMonoid prxMaybe
   Data.checkFunctor prx2Maybe
   Data.checkFoldableFunctor prx2Maybe
-  Data.checkEqShow prxMaybe
-  Data.checkOrdShow prxMaybe
-  Data.checkBoundedShow prxMaybe
-  Data.checkSemigroupShow prxMaybe
-  Data.checkMonoidShow prxMaybe
-  Data.checkFunctorShow prx2Maybe
-  Data.checkFoldableFunctorShow prx2Maybe
   Control.checkApply prx2Maybe
   Control.checkApplicative prx2Maybe
   Control.checkAlt prx2Maybe
@@ -34,6 +27,22 @@ checkMaybe = checkLaws "Maybe" do
   Control.checkMonad prx2Maybe
   Control.checkMonadZero prx2Maybe
   Control.checkExtend prx2Maybe
+  Data.checkEqShow prxMaybe
+  Data.checkOrdShow prxMaybe
+  Data.checkBoundedShow prxMaybe
+  Data.checkSemigroupShow prxMaybe
+  Data.checkMonoidShow prxMaybe
+  Data.checkFunctorShow prx2Maybe
+  Data.checkFoldableFunctorShow prx2Maybe
+  Control.checkApplyShow prx2Maybe
+  Control.checkApplicativeShow prx2Maybe
+  Control.checkAltShow prx2Maybe
+  Control.checkPlusShow prx2Maybe
+  Control.checkAlternativeShow prx2Maybe
+  Control.checkBindShow prx2Maybe
+  Control.checkMonadShow prx2Maybe
+  Control.checkMonadZeroShow prx2Maybe
+  Control.checkExtendShow prx2Maybe
   where
   prxMaybe = Proxy ∷ Proxy (Maybe A)
   prx2Maybe = Proxy2 ∷ Proxy2 Maybe

--- a/test/Test/Data/Maybe.purs
+++ b/test/Test/Data/Maybe.purs
@@ -18,6 +18,13 @@ checkMaybe = checkLaws "Maybe" do
   Data.checkMonoid prxMaybe
   Data.checkFunctor prx2Maybe
   Data.checkFoldableFunctor prx2Maybe
+  Data.checkEqShow prxMaybe
+  Data.checkOrdShow prxMaybe
+  Data.checkBoundedShow prxMaybe
+  Data.checkSemigroupShow prxMaybe
+  Data.checkMonoidShow prxMaybe
+  Data.checkFunctorShow prx2Maybe
+  Data.checkFoldableFunctorShow prx2Maybe
   Control.checkApply prx2Maybe
   Control.checkApplicative prx2Maybe
   Control.checkAlt prx2Maybe

--- a/test/Test/Data/Ordering.purs
+++ b/test/Test/Data/Ordering.purs
@@ -14,5 +14,10 @@ checkOrdering = checkLaws "Ordering" do
   Data.checkBounded prxOrdering
   Data.checkBoundedEnum prxOrdering
   Data.checkSemigroup prxOrdering
+  Data.checkEqShow prxOrdering
+  Data.checkOrdShow prxOrdering
+  Data.checkBoundedShow prxOrdering
+  Data.checkBoundedEnumShow prxOrdering
+  Data.checkSemigroupShow prxOrdering
   where
   prxOrdering = Proxy ∷ Proxy Ordering

--- a/test/Test/Data/Tuple.purs
+++ b/test/Test/Data/Tuple.purs
@@ -18,6 +18,13 @@ checkTuple = checkLaws "Tuple" do
   Data.checkMonoid prxTuple
   Data.checkFunctor prx2Tuple
   Data.checkFoldableFunctor prx2Tuple
+  Data.checkEqShow prxTuple
+  Data.checkOrdShow prxTuple
+  Data.checkBoundedShow prxTuple
+  Data.checkSemigroupShow prxTuple
+  Data.checkMonoidShow prxTuple
+  Data.checkFunctorShow prx2Tuple
+  Data.checkFoldableFunctorShow prx2Tuple
   Control.checkSemigroupoid prx3Tuple
   Control.checkApply prx2Tuple
   Control.checkApplicative prx2Tuple

--- a/test/Test/Data/Tuple.purs
+++ b/test/Test/Data/Tuple.purs
@@ -18,13 +18,6 @@ checkTuple = checkLaws "Tuple" do
   Data.checkMonoid prxTuple
   Data.checkFunctor prx2Tuple
   Data.checkFoldableFunctor prx2Tuple
-  Data.checkEqShow prxTuple
-  Data.checkOrdShow prxTuple
-  Data.checkBoundedShow prxTuple
-  Data.checkSemigroupShow prxTuple
-  Data.checkMonoidShow prxTuple
-  Data.checkFunctorShow prx2Tuple
-  Data.checkFoldableFunctorShow prx2Tuple
   Control.checkSemigroupoid prx3Tuple
   Control.checkApply prx2Tuple
   Control.checkApplicative prx2Tuple
@@ -32,6 +25,20 @@ checkTuple = checkLaws "Tuple" do
   Control.checkMonad prx2Tuple
   Control.checkExtend prx2Tuple
   Control.checkComonad prx2Tuple
+  Data.checkEqShow prxTuple
+  Data.checkOrdShow prxTuple
+  Data.checkBoundedShow prxTuple
+  Data.checkSemigroupShow prxTuple
+  Data.checkMonoidShow prxTuple
+  Data.checkFunctorShow prx2Tuple
+  Data.checkFoldableFunctorShow prx2Tuple
+  Control.checkSemigroupoidShow prx3Tuple
+  Control.checkApplyShow prx2Tuple
+  Control.checkApplicativeShow prx2Tuple
+  Control.checkBindShow prx2Tuple
+  Control.checkMonadShow prx2Tuple
+  Control.checkExtendShow prx2Tuple
+  Control.checkComonadShow prx2Tuple
   where
   prxTuple = Proxy ∷ Proxy (Tuple A B)
   prx2Tuple = Proxy2 ∷ Proxy2 (Tuple C)

--- a/test/Test/Data/Unit.purs
+++ b/test/Test/Data/Unit.purs
@@ -20,5 +20,16 @@ checkUnit = checkLaws "Unit" do
   Data.checkCommutativeRing prxUnit
   Data.checkHeytingAlgebra prxUnit
   Data.checkBooleanAlgebra prxUnit
+  Data.checkEqShow prxUnit
+  Data.checkOrdShow prxUnit
+  Data.checkBoundedShow prxUnit
+  Data.checkBoundedEnumShow prxUnit
+  Data.checkSemigroupShow prxUnit
+  Data.checkMonoidShow prxUnit
+  Data.checkSemiringShow prxUnit
+  Data.checkRingShow prxUnit
+  Data.checkCommutativeRingShow prxUnit
+  Data.checkHeytingAlgebraShow prxUnit
+  Data.checkBooleanAlgebraShow prxUnit
   where
   prxUnit = Proxy ∷ Proxy Unit

--- a/test/Test/Prim/Array.purs
+++ b/test/Test/Prim/Array.purs
@@ -25,6 +25,21 @@ checkArray = checkLaws "Array" do
   Control.checkAlternative prx2Array
   Control.checkMonadZero prx2Array
   Control.checkMonadPlus prx2Array
+  Data.checkEqShow prxArray
+  Data.checkOrdShow prxArray
+  Data.checkFunctorShow prx2Array
+  Data.checkFoldableFunctorShow prx2Array
+  Control.checkApplyShow prx2Array
+  Control.checkApplicativeShow prx2Array
+  Control.checkBindShow prx2Array
+  Control.checkMonadShow prx2Array
+  Data.checkSemigroupShow prxArray
+  Data.checkMonoidShow prxArray
+  Control.checkAltShow prx2Array
+  Control.checkPlusShow prx2Array
+  Control.checkAlternativeShow prx2Array
+  Control.checkMonadZeroShow prx2Array
+  Control.checkMonadPlusShow prx2Array
   where
   prxArray = Proxy ∷ Proxy (Array A)
   prx2Array = Proxy2 ∷ Proxy2 Array

--- a/test/Test/Prim/Boolean.purs
+++ b/test/Test/Prim/Boolean.purs
@@ -15,5 +15,11 @@ checkBoolean = checkLaws "Boolean" do
   Data.checkBoundedEnum prxBoolean
   Data.checkHeytingAlgebra prxBoolean
   Data.checkBooleanAlgebra prxBoolean
+  Data.checkEqShow prxBoolean
+  Data.checkOrdShow prxBoolean
+  Data.checkBoundedShow prxBoolean
+  Data.checkBoundedEnumShow prxBoolean
+  Data.checkHeytingAlgebraShow prxBoolean
+  Data.checkBooleanAlgebraShow prxBoolean
   where
   prxBoolean = Proxy ∷ Proxy Boolean

--- a/test/Test/Prim/Int.purs
+++ b/test/Test/Prim/Int.purs
@@ -15,5 +15,11 @@ checkInt = checkLaws "Int" do
   Data.checkSemiring prxInt
   Data.checkEuclideanRing prxInt
   Data.checkRing prxInt
+  Data.checkEqShow prxInt
+  Data.checkOrdShow prxInt
+  Data.checkCommutativeRingShow prxInt
+  Data.checkSemiringShow prxInt
+  Data.checkEuclideanRingShow prxInt
+  Data.checkRingShow prxInt
   where
   prxInt = Proxy ∷ Proxy Int

--- a/test/Test/Prim/Number.purs
+++ b/test/Test/Prim/Number.purs
@@ -17,6 +17,13 @@ checkNumber = checkLaws "Number" do
   Data.checkEuclideanRing prxNumber
   Data.checkDivisionRing prxNumber
   Data.checkCommutativeRing prxNumber
+  Data.checkEqShow prxNumber
+  Data.checkOrdShow prxNumber
+  Data.checkSemiringShow prxNumber
+  Data.checkRingShow prxNumber
+  Data.checkEuclideanRingShow prxNumber
+  Data.checkDivisionRingShow prxNumber
+  Data.checkCommutativeRingShow prxNumber
   where
   prxNumber = Proxy ∷ Proxy ApproxNumber
 
@@ -36,6 +43,7 @@ instance eqApproxNumber :: Eq ApproxNumber where
   eq (ApproxNumber x) (ApproxNumber y) = x =~= y
 
 derive newtype instance ordApproxNumber :: Ord ApproxNumber
+derive newtype instance showApproxNumber :: Show ApproxNumber
 derive newtype instance semiringApproxNumber :: Semiring ApproxNumber
 derive newtype instance ringApproxNumber :: Ring ApproxNumber
 derive newtype instance commutativeRingApproxNumber :: CommutativeRing ApproxNumber

--- a/test/Test/Prim/String.purs
+++ b/test/Test/Prim/String.purs
@@ -13,5 +13,9 @@ checkString = checkLaws "String" do
   Data.checkOrd prxString
   Data.checkSemigroup prxString
   Data.checkMonoid prxString
+  Data.checkEqShow prxString
+  Data.checkOrdShow prxString
+  Data.checkSemigroupShow prxString
+  Data.checkMonoidShow prxString
   where
   prxString = Proxy ∷ Proxy String


### PR DESCRIPTION
QuickCheck comes shipped with a `Result` type and some comparison functions like `(===)` and `(<?)`, to make reporting the failed test case as natural as using `Boolean`, while relying on an additional `Show` predicate on the data type. Using these, and some additional functions from purescript-quickcheck-combinators, new implementations for each test suite have been defined, with a `*Show` suffix (i.e. `checkEqShow :: ... Eq a => Show a => ...`), and rely on `Result` as the `Testable` instance to run in `quickCheck'`.

It's a pretty simple set of additional functions, I'm surprised they didn't exist before. Please let me know if you need anything to get this PR approved! Thank you!